### PR TITLE
Feat/get supported regions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -391,3 +391,11 @@ dist
 /.env
 /.env.*.local
 *._local.ts
+
+# Ignore specific files
+/src/database/seeding/seeding.service.ts
+/src/database/data-source.ts
+
+# Package files
+/package-lock.json
+/package.json

--- a/.gitignore
+++ b/.gitignore
@@ -393,7 +393,6 @@ dist
 *._local.ts
 
 # Ignore specific files
-/src/database/seeding/seeding.service.ts
 /src/database/data-source.ts
 
 # Package files

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { SeedingModule } from './database/seeding/seeding.module';
 import HealthController from './health.controller';
 import { AuthModule } from './modules/auth/auth.module';
 import { UserModule } from './modules/user/user.module';
+import { RegionsModule } from './modules/regions/regions.module';
 import authConfig from 'config/auth.config';
 
 @Module({
@@ -57,6 +58,7 @@ import authConfig from 'config/auth.config';
     SeedingModule,
     AuthModule,
     UserModule,
+    RegionsModule,
   ],
   controllers: [HealthController],
 })

--- a/src/database/seeding/seeding.service.ts
+++ b/src/database/seeding/seeding.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import { User } from '../../modules/user/entities/user.entity';
+import { Regions } from '../../modules/regions/entities/region.entity';
 
 @Injectable()
 export class SeedingService {
@@ -8,45 +9,116 @@ export class SeedingService {
 
   async seedDatabase() {
     const userRepository = this.dataSource.getRepository(User);
+    const regionsRepository = this.dataSource.getRepository(Regions);
 
     try {
+      // Check and seed users
       const existingUsers = await userRepository.count();
-      if (existingUsers > 0) {
-        Logger.log('Database is already populated. Skipping seeding.');
-        return;
+      if (existingUsers === 0) {
+        const queryRunner = this.dataSource.createQueryRunner();
+        await queryRunner.connect();
+        await queryRunner.startTransaction();
+
+        try {
+          const u1 = userRepository.create({
+            first_name: 'John',
+            last_name: 'Smith',
+            email: 'john.smith@example.com',
+            password: 'password',
+          });
+          const u2 = userRepository.create({
+            first_name: 'Jane',
+            last_name: 'Smith',
+            email: 'jane.smith@example.com',
+            password: 'password',
+          });
+
+          await userRepository.save([u1, u2]);
+
+          const savedUsers = await userRepository.find();
+          if (savedUsers.length !== 2) {
+            throw new Error('Failed to create all users');
+          }
+
+          await queryRunner.commitTransaction();
+        } catch (error) {
+          await queryRunner.rollbackTransaction();
+          console.error('User seeding failed:', error.message);
+        } finally {
+          await queryRunner.release();
+        }
+      } else {
+        Logger.log('Users are already seeded.');
       }
 
-      const queryRunner = this.dataSource.createQueryRunner();
-      await queryRunner.connect();
-      await queryRunner.startTransaction();
+      // Check and seed regions
+      const existingRegions = await regionsRepository.count();
+      if (existingRegions === 0) {
+        const queryRunner = this.dataSource.createQueryRunner();
+        await queryRunner.connect();
+        await queryRunner.startTransaction();
 
-      try {
-        const u1 = userRepository.create({
-          first_name: 'John',
-          last_name: 'Smith',
-          email: 'john.smith@example.com',
-          password: 'password',
-        });
-        const u2 = userRepository.create({
-          first_name: 'Jane',
-          last_name: 'Smith',
-          email: 'jane.smith@example.com',
-          password: 'password',
-        });
+        try {
+          const regions = [
+            {
+              regionCode: 'NA',
+              regionName: 'North America',
+              countryCode: 'US',
+              status: 1,
+              createdOn: new Date(),
+              createdBy: 'admin',
+              modifiedOn: new Date(),
+              modifiedBy: 'admin',
+            },
+            {
+              regionCode: 'EU',
+              regionName: 'Europe',
+              countryCode: 'EU',
+              status: 1,
+              createdOn: new Date(),
+              createdBy: 'admin',
+              modifiedOn: new Date(),
+              modifiedBy: 'admin',
+            },
+            {
+              regionCode: 'AS',
+              regionName: 'Asia',
+              countryCode: 'AS',
+              status: 1,
+              createdOn: new Date(),
+              createdBy: 'admin',
+              modifiedOn: new Date(),
+              modifiedBy: 'admin',
+            },
+            {
+              regionCode: 'AF',
+              regionName: 'Africa',
+              countryCode: 'AF',
+              status: 1,
+              createdOn: new Date(),
+              createdBy: 'admin',
+              modifiedOn: new Date(),
+              modifiedBy: 'admin',
+            },
+         
+          ];
 
-        await userRepository.save([u1, u2]);
+          await regionsRepository.save(regions);
 
-        const savedUsers = await userRepository.find();
-        if (savedUsers.length !== 2) {
-          throw new Error('Failed to create all users');
+          const savedRegions = await regionsRepository.find();
+          if (savedRegions.length !== regions.length) {
+            throw new Error('Failed to create all regions');
+          }
+
+          await queryRunner.commitTransaction();
+        } catch (error) {
+          await queryRunner.rollbackTransaction();
+          console.error('Region seeding failed:', error.message);
+        } finally {
+          await queryRunner.release();
         }
-
-        await queryRunner.commitTransaction();
-      } catch (error) {
-        await queryRunner.rollbackTransaction();
-        console.error('Seeding failed:', error.message);
-      } finally {
-        await queryRunner.release();
+      } else {
+        Logger.log('Regions are already seeded.');
       }
     } catch (error) {
       console.error('Error while checking for existing data:', error.message);

--- a/src/modules/regions/_tests_/regions.service.spec.ts
+++ b/src/modules/regions/_tests_/regions.service.spec.ts
@@ -1,0 +1,53 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { RegionsService } from '../regions.service';
+import { Regions } from '../entities/region.entity';
+
+const mockRegions = [
+  {
+    id: '1',
+    regionCode: 'NA',
+    regionName: 'North America',
+    countryCode: 'US',
+    status: 1,
+    createdOn: new Date(),
+    createdBy: 'admin',
+    modifiedOn: new Date(),
+    modifiedBy: 'admin',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+];
+
+describe('RegionsService', () => {
+  let service: RegionsService;
+  let repository: Repository<Regions>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RegionsService,
+        {
+          provide: getRepositoryToken(Regions),
+          useValue: {
+            find: jest.fn().mockResolvedValue(mockRegions),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<RegionsService>(RegionsService);
+    repository = module.get<Repository<Regions>>(getRepositoryToken(Regions));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should return all regions', async () => {
+    const regions = await service.findAll();
+    expect(regions).toEqual(mockRegions);
+    expect(repository.find).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/regions/entities/region.entity.ts
+++ b/src/modules/regions/entities/region.entity.ts
@@ -1,0 +1,37 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity()
+export class Regions {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  regionCode: string;
+
+  @Column()
+  regionName: string;
+
+  @Column()
+  countryCode: string;
+
+  @Column('int')
+  status: number;
+
+  @Column({ type: 'timestamp' })
+  createdOn: Date;
+
+  @Column()
+  createdBy: string;
+
+  @Column({ type: 'timestamp' })
+  modifiedOn: Date;
+
+  @Column()
+  modifiedBy: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/modules/regions/regions.controller.ts
+++ b/src/modules/regions/regions.controller.ts
@@ -1,0 +1,54 @@
+import { Controller, Get, HttpException, HttpStatus } from '@nestjs/common';
+import { RegionsService } from './regions.service';
+import { Regions } from './entities/region.entity';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+@ApiTags('regions')
+@Controller('regions')
+export class RegionsController {
+  constructor(private readonly regionsService: RegionsService) {}
+  @ApiOperation({ summary: 'Get supported regions' })
+  @ApiResponse({
+    status: 200,
+    description: 'The regions have been successfully fetched.',
+    schema: {
+      example: {
+        status: 'success',
+        data: {
+          regions: [
+            {
+              id: 'string',
+              region: 'String',
+            },
+          ],
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
+  @Get()
+  async findAll(): Promise<any> {
+    try {
+      const regions = await this.regionsService.findAll();
+      const formattedRegions = regions.map(region => ({
+        id: region.id,
+        region: region.regionName,
+      }));
+      return {
+        status: 'success',
+        data: {
+          regions: formattedRegions,
+        },
+      };
+    } catch (error) {
+      throw new HttpException(
+        {
+          status: 'error',
+          message: 'You are not authorised for this action',
+          statusCode: HttpStatus.UNAUTHORIZED,
+        },
+        HttpStatus.UNAUTHORIZED
+      );
+    }
+  }
+}

--- a/src/modules/regions/regions.controller.ts
+++ b/src/modules/regions/regions.controller.ts
@@ -44,8 +44,8 @@ export class RegionsController {
       throw new HttpException(
         {
           status: 'error',
-          message: 'You are not authorised for this action',
-          statusCode: HttpStatus.UNAUTHORIZED,
+          message: 'You are not authorized for this action',
+          status_code: HttpStatus.UNAUTHORIZED,
         },
         HttpStatus.UNAUTHORIZED
       );

--- a/src/modules/regions/regions.module.ts
+++ b/src/modules/regions/regions.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { RegionsService } from './regions.service';
+import { RegionsController } from './regions.controller';
+import { Regions } from './entities/region.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Regions])],
+  providers: [RegionsService],
+  controllers: [RegionsController],
+})
+export class RegionsModule {}

--- a/src/modules/regions/regions.service.ts
+++ b/src/modules/regions/regions.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Regions } from './entities/region.entity';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+@Injectable()
+export class RegionsService {
+  constructor(
+    @InjectRepository(Regions)
+    private regionsRepository: Repository<Regions>
+  ) {}
+
+  @ApiOperation({ summary: 'Get all regions' })
+  @ApiResponse({
+    status: 200,
+    description: 'The regions have been successfully fetched.',
+    schema: {
+      example: {
+        status: 'success',
+        data: {
+          regions: [
+            {
+              id: 'string',
+              region: 'String',
+            },
+          ],
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
+  async findAll(): Promise<Regions[]> {
+    return await this.regionsRepository.find();
+  }
+}


### PR DESCRIPTION

### What does this PR do?

This PR implements an endpoint for getting the list of supported regions:

- **Added GET /api/v1/regions Endpoint:** Returns the list of supported regions.
- **Response Handling:** Provides appropriate responses for missing or invalid refresh tokens.
- **Error Handling:** Returns specific HTTP status codes and messages based on authorization status.

### How should this be manually tested?

1. **Register a User:**
   - Use the `POST /api/v1/auth/register` endpoint to register a new user.

2. **Login User:**
   - Make a `POST` request to `/api/v1/auth/login` with the registered user's password and email in the request body.
   - Check the response for appropriate status codes and messages.

3. **Get Supported Regions:**
   - Make a `GET` request to `/api/v1/regions` with a valid token.
   - Verify the response contains the list of supported regions.

4. **Edge Cases:**
   - **Invalid Token:** Test with an invalid token to ensure the endpoint returns a `401 Unauthorized` status with the correct message.
   - **Missing Token:** Test without a token to ensure the endpoint returns a `401 Unauthorized` status with the correct message.

### Checklist

- [x] Implemented `GET /api/v1/regions` endpoint in the `regions.controller.ts`.
- [x] Added `findAll` method in the `RegionsService`.
- [x] Modified `regions.controller.ts` to provide appropriate responses for various cases.
- [x] Tested endpoint functionality to ensure it correctly handles valid and invalid tokens.
- [x] Added appropriate HTTP status codes and response messages for edge cases.
- [x] Added tests for this endpoint.

### Response Examples

**Success:**
```json
{
  "status": "success",
  "data": {
    "regions": [
      {
        "id": "string",
        "region": "string"
      }
    ]
  }
}
```

**Error:**
```json
{
  "status": "error",
  "message": "You are not authorized for this action",
  "status_code": 401
}
```

### Link to Issue

Link to this issue: #34