### PR TITLE
feat: adding members to organisation

### DIFF
--- a/src/modules/organisations/dto/add-user-dto.ts
+++ b/src/modules/organisations/dto/add-user-dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class AddUserDto {
+  @IsString()
+  readonly userId: string;
+}

--- a/src/modules/organisations/entities/organisations.entity.ts
+++ b/src/modules/organisations/entities/organisations.entity.ts
@@ -6,6 +6,8 @@ import {
   UpdateDateColumn,
   ManyToOne,
   OneToMany,
+  ManyToMany,
+  JoinTable,
 } from 'typeorm';
 import { User } from '../../user/entities/user.entity';
 import { OrganisationPreference } from './org-preferences.entity';
@@ -48,4 +50,8 @@ export class Organisation extends AbstractBaseEntity {
 
   @OneToMany(() => OrganisationPreference, preference => preference.organisation)
   preferences: OrganisationPreference[];
+
+  @ManyToMany(() => User, user => user.member_organisations)
+  @JoinTable()
+  members: User[];
 }

--- a/src/modules/organisations/organisations.controller.ts
+++ b/src/modules/organisations/organisations.controller.ts
@@ -3,6 +3,7 @@ import { OrganisationsService } from './organisations.service';
 import { OrganisationRequestDto } from './dto/organisation.dto';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { UpdateOrganisationDto } from './dto/update-organisation.dto';
+import { AddUserDto } from './dto/add-user-dto';
 
 @ApiBearerAuth()
 @ApiTags('Organisation')
@@ -26,5 +27,13 @@ export class OrganisationsController {
   async update(@Param('id') id: string, @Body() updateOrganisationDto: UpdateOrganisationDto) {
     const updatedOrg = await this.organisationsService.updateOrganisation(id, updateOrganisationDto);
     return { message: 'Organisation successfully updated', org: updatedOrg };
+  }
+
+  @ApiOperation({ summary: 'Add User To Organisation' })
+  @Post('/:org_id/users')
+  async addUser(@Param('org_id') orgId: string, @Body() addUserDto: AddUserDto, @Request() req) {
+    const userId = addUserDto.userId;
+    const currentUser = req['user'];
+    return this.organisationsService.addUser(orgId, userId, currentUser.sub);
   }
 }

--- a/src/modules/organisations/tests/mocks/new-user.mock.ts
+++ b/src/modules/organisations/tests/mocks/new-user.mock.ts
@@ -1,0 +1,26 @@
+import { User } from '../../../user/entities/user.entity';
+import { v4 as uuidv4 } from 'uuid';
+
+export enum UserType {
+  SUPER_ADMIN = 'super_admin',
+  ADMIN = 'admin',
+  USER = 'vendor',
+}
+
+export const newUser = {
+  id: uuidv4(),
+  created_at: new Date(),
+  updated_at: new Date(),
+  first_name: 'Marie',
+  last_name: 'James',
+  email: 'marie.james@example.com',
+  password: 'pass123',
+  hashPassword: async () => {},
+  is_active: true,
+  attempts_left: 3,
+  time_left: 3600,
+  owned_organisations: [],
+  created_organisations: [],
+  member_organisations: [],
+  user_type: UserType.USER,
+};

--- a/src/modules/organisations/tests/mocks/organisation.mock.ts
+++ b/src/modules/organisations/tests/mocks/organisation.mock.ts
@@ -22,6 +22,25 @@ export const createMockOrganisation = (): Organisation => {
     time_left: 3600,
     owned_organisations: [],
     created_organisations: [],
+    member_organisations: [],
+    user_type: UserType.ADMIN,
+  };
+
+  const member = {
+    id: uuidv4(),
+    created_at: new Date(),
+    updated_at: new Date(),
+    first_name: 'Marie',
+    last_name: 'James',
+    email: 'marie.james@example.com',
+    password: 'pass123',
+    hashPassword: async () => {},
+    is_active: true,
+    attempts_left: 3,
+    time_left: 3600,
+    owned_organisations: [],
+    created_organisations: [],
+    member_organisations: [],
     user_type: UserType.ADMIN,
   };
 
@@ -41,6 +60,7 @@ export const createMockOrganisation = (): Organisation => {
     updated_at: new Date(),
     isDeleted: false,
     preferences: [],
+    members: [member],
   };
 };
 

--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -1,4 +1,4 @@
-import { BeforeInsert, Column, Entity, OneToMany } from 'typeorm';
+import { BeforeInsert, Column, Entity, ManyToMany, OneToMany } from 'typeorm';
 import * as bcrypt from 'bcrypt';
 import { AbstractBaseEntity } from '../../../entities/base.entity';
 import { Organisation } from '../../../modules/organisations/entities/organisations.entity';
@@ -44,6 +44,9 @@ export class User extends AbstractBaseEntity {
 
   @OneToMany(() => Organisation, organisation => organisation.creator)
   created_organisations: Organisation[];
+
+  @ManyToMany(() => Organisation, organistion => organistion.members)
+  member_organisations: Organisation[];
 
   @BeforeInsert()
   async hashPassword() {


### PR DESCRIPTION
## What does this PR do?
This PR creates an endpoint that allows organisation owners to add new members

## How to Test
1. Create an organisation using POST `/api/v1/organisations`
2. Create a new user and get the user ID
3. Add user to the organisation using POST `/api/v1/organisations/:org_id/users`

## Edge Cases
- Test whether the organisation exists
- Test whether the current user is the owner of the organisation
- Test whether the specified user exists
- Test whether the specified user is already a member of the organisation

## Checklist
- [x] creating the `/api/v1/organisations/:org_id/users`
- [x] validating the org_id parameter
- [x] checking whether the current user is the owner of the organisation
- [x] validating the user_id parameter
- [x] checking whether the specified user is already a member
- [x] writing tests to validate parameters and to test edge cases

## Responses
### Successful Response
```
{
        status: 'Success',
        message: 'User added successfully',
        status_code: 200,
}
```
### Error Response when the organisation does not exist
```
{
        status: 'error',
        message: 'Organisation not found',
        status_code: 404,
}
```
### Error Response when the current user is not the owner of the organisation
```
{
         status: 'Forbidden',
          message: 'Only admins can add users',
          status_code: 403,
}
```
### Error Response when the user does not exist
```
{
       status: 'error',
        message: 'User not found',
        status_code: 404,
}
```
### Error Response when the user is already a member of the organisation
```
{
          status: 'error',
          message: 'User already added to organization.',
          status_code: 409,
}
```


## Associated Issue
Issue #274 