### PR TITLE
feat: implement organization deletion

### DIFF
--- a/src/modules/organisations/organisations.controller.ts
+++ b/src/modules/organisations/organisations.controller.ts
@@ -1,8 +1,9 @@
-import { Body, Controller, Param, Patch, Post, Request } from '@nestjs/common';
+import { Body, Controller, Delete, Param, Patch, Post, Request, Res } from '@nestjs/common';
 import { OrganisationsService } from './organisations.service';
 import { OrganisationRequestDto } from './dto/organisation.dto';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { UpdateOrganisationDto } from './dto/update-organisation.dto';
+import { number } from 'joi';
 
 @ApiBearerAuth()
 @ApiTags('Organisation')
@@ -14,6 +15,12 @@ export class OrganisationsController {
   async create(@Body() createOrganisationDto: OrganisationRequestDto, @Request() req) {
     const user = req['user'];
     return this.organisationsService.create(createOrganisationDto, user.sub);
+  }
+
+  @Delete(':org_id')
+  async delete(@Param('org_id') id: string, @Res() response: Response) {
+    this.organisationsService;
+    return this.organisationsService.deleteOrganization(id);
   }
 
   @ApiOperation({ summary: 'Update Organisation' })

--- a/src/modules/organisations/organisations.service.ts
+++ b/src/modules/organisations/organisations.service.ts
@@ -48,10 +48,26 @@ export class OrganisationsService {
   }
 
   async deleteOrganization(id: string) {
-    const org = await this.organisationRepository.findOneBy({ id });
-    org.isDeleted = true;
-    await this.organisationRepository.save(org);
-    return HttpStatus.NO_CONTENT;
+    try {
+      const org = await this.organisationRepository.findOneBy({ id });
+      if (!org) {
+        throw new NotFoundException(`Organisation with id ${id} not found`);
+      }
+      org.isDeleted = true;
+      await this.organisationRepository.save(org);
+      return HttpStatus.NO_CONTENT;
+    } catch (error) {
+      if (error instanceof NotFoundException || error instanceof BadRequestException) {
+        throw error;
+      }
+      throw new InternalServerErrorException(`An internal server error occurred: ${error.message}`);
+    }
+    // const org = await this.organisationRepository.findOneBy({ id });
+    // if (org.isDeleted === false) {
+    //   org.isDeleted = true;
+    // }
+    // await this.organisationRepository.save(org);
+    // return HttpStatus.NO_CONTENT;
   }
   async emailExists(email: string): Promise<boolean> {
     const emailFound = await this.organisationRepository.findBy({ email });

--- a/src/modules/organisations/organisations.service.ts
+++ b/src/modules/organisations/organisations.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  HttpStatus,
   Injectable,
   InternalServerErrorException,
   NotFoundException,
@@ -46,6 +47,12 @@ export class OrganisationsService {
     return { status: 'success', message: 'organisation created successfully', data: mappedResponse };
   }
 
+  async deleteOrganization(id: string) {
+    const org = await this.organisationRepository.findOneBy({ id });
+    org.isDeleted = true;
+    await this.organisationRepository.save(org);
+    return HttpStatus.NO_CONTENT;
+  }
   async emailExists(email: string): Promise<boolean> {
     const emailFound = await this.organisationRepository.findBy({ email });
     return emailFound?.length ? true : false;

--- a/src/modules/organisations/tests/organisations.service.spec.ts
+++ b/src/modules/organisations/tests/organisations.service.spec.ts
@@ -89,6 +89,39 @@ describe('OrganisationsService', () => {
     });
   });
 
+  describe('delete organization', () => {
+    it('should delete an organisation successfully', async () => {
+      const id = '1';
+      const organisation = new Organisation();
+      organisation.id = id;
+
+      jest.spyOn(organisationRepository, 'findOneBy').mockResolvedValueOnce(organisation);
+      jest.spyOn(organisationRepository, 'save').mockResolvedValueOnce(organisation);
+
+      const result = await service.deleteOrganization(id);
+
+      expect(organisationRepository.findOneBy).toHaveBeenCalledWith({ id });
+      expect(organisationRepository.save).toHaveBeenCalledWith(expect.objectContaining({ isDeleted: true }));
+      expect(result).toEqual(204); // HttpStatus.NO_CONTENT
+    });
+
+    it('should throw NotFoundException if organisation not found', async () => {
+      const id = '1';
+
+      jest.spyOn(organisationRepository, 'findOneBy').mockResolvedValueOnce(null);
+
+      await expect(service.deleteOrganization(id)).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw InternalServerErrorException if an unexpected error occurs', async () => {
+      const id = '1';
+
+      jest.spyOn(organisationRepository, 'findOneBy').mockRejectedValueOnce(new Error('Unexpected error'));
+
+      await expect(service.deleteOrganization(id)).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+
   describe('update organisation', () => {
     it('should update an organisation successfully', async () => {
       const id = '1';


### PR DESCRIPTION
**What does the PR do?**
This PR is about deleting Organisation

**How should this be manually tested?**
Send a post request to /api/v1/organizations/:org_id with a request example as below

DELETE /api/v1/organizations/:org_id
Content-Type: application/json
Authorization: Bearer <token>

**Checklist of what you did**

- [ ]  Develop server-side logic to handle organization deletion requests.
- [ ] Validate and sanitize incoming organization ID data.
- [ ]  Validate the user deleting the organization is the owner.
- [ ]  Change the specified organizationdeleted attribute upon successful validation to true in the database.
- [ ]  Keep all related data of the specified organization intact.


**Reference Issue**
#https://github.com/hngprojects/hng_boilerplate_nestjs/issues/126