### PR TITLE
feat: get user by id

### DIFF
--- a/src/modules/user/dto/get-user-by-id-response.dto.ts
+++ b/src/modules/user/dto/get-user-by-id-response.dto.ts
@@ -1,0 +1,10 @@
+import UserInterface from '../interfaces/UserInterface';
+
+export class GetUserByIdResponseDto {
+  status_code: 200;
+  user: Omit<Partial<UserInterface>, 'password'>;
+
+  constructor(user: Omit<Partial<UserInterface>, 'password'>) {
+    this.user = user;
+  }
+}

--- a/src/modules/user/tests/user.service.spec.ts
+++ b/src/modules/user/tests/user.service.spec.ts
@@ -258,4 +258,48 @@ describe('UserService', () => {
       expect(mockUserRepository.save).not.toHaveBeenCalled();
     });
   });
+
+  describe('getUserRecord', () => {
+    it('should return a user by email', async () => {
+      const email = 'test@example.com';
+      const userResponseDto: UserResponseDTO = {
+        id: 'uuid',
+        email: 'test@example.com',
+        first_name: 'John',
+        last_name: 'Doe',
+      };
+
+      mockUserRepository.findOne.mockResolvedValueOnce(userResponseDto);
+
+      const result = await service.getUserRecord({ identifier: email, identifierType: 'email' });
+      expect(result).toEqual(userResponseDto);
+      expect(repository.findOne).toHaveBeenCalledWith({ where: { email } });
+    });
+
+    it('should return a user by id', async () => {
+      const id = '1';
+      const userResponseDto: UserResponseDTO = {
+        id: 'some-uuid-here',
+        email: 'test@example.com',
+        first_name: 'John',
+        last_name: 'Doe',
+      };
+
+      mockUserRepository.findOne.mockResolvedValueOnce(userResponseDto);
+
+      const result = await service.getUserRecord({ identifier: id, identifierType: 'id' });
+      expect(result).toEqual(userResponseDto);
+      expect(repository.findOne).toHaveBeenCalledWith({ where: { id } });
+    });
+
+    it('should handle exceptions gracefully', async () => {
+      const identifierOptions: UserIdentifierOptionsType = { identifier: 'unknown', identifierType: 'email' };
+
+      mockUserRepository.findOne.mockImplementationOnce(() => {
+        throw new Error('Test error');
+      });
+
+      await expect(service.getUserRecord(identifierOptions)).rejects.toThrow('Test error');
+    });
+  });
 });

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -1,9 +1,21 @@
-import { Controller, Patch, Param, Body, UsePipes, ValidationPipe, Request, Req } from '@nestjs/common';
+import {
+  Controller,
+  Patch,
+  Param,
+  Body,
+  UsePipes,
+  ValidationPipe,
+  Request,
+  Req,
+  Get,
+  HttpException,
+} from '@nestjs/common';
 import UserService from './user.service';
 import { UpdateUserDto } from './dto/update-user-dto';
 import { UserPayload } from './interfaces/user-payload.interface';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { DeactivateAccountDto } from './dto/deactivate-account.dto';
+import { GetUserByIdResponseDto } from './dto/get-user-by-id-response.dto';
 
 @ApiBearerAuth()
 @ApiTags('Users')
@@ -44,5 +56,33 @@ export class UserController {
       status_code: 200,
       message: result.message,
     };
+  }
+
+  @ApiOperation({ summary: 'Get user' })
+  @ApiResponse({
+    status: 200,
+    description: 'Get user by Id',
+    type: GetUserByIdResponseDto,
+  })
+  @Get(':userId')
+  async getUserById(@Param() { userId }: { userId: string }) {
+    try {
+      const { password, ...userData } = await this.userService.getUserRecord({
+        identifier: userId,
+        identifierType: 'id',
+      });
+      return {
+        status_code: 200,
+        user: userData,
+      };
+    } catch (e) {
+      throw new HttpException(
+        {
+          status_code: 500,
+          error: 'Internal Server Error',
+        },
+        500
+      );
+    }
   }
 }


### PR DESCRIPTION
## What does the PR do?
This PR is about getting a user by Id

## How should this be manually tested?
Send a GET request to `/api/v1/users/:userId` with access token in the authorization header.

## Checklist of what you did
- [x] Implemented endpoint to get a user by the `user_id`.
- [x] Handle error for invalid user id in the params.
- [x] Integrate with auth guard to prevent request from unauthorized access.
- [x] Implement safety measure to avoid leak of user sensitive data such as password.
- [x] Requests to the endpoint must include a valid authentication token in the Authorization header.
- [x] Returned success `status_code ` with the user data.
- [x] Unit test the user service to ensure it works as expected.

## Test Screenshot

![image](https://github.com/user-attachments/assets/14689777-966d-4074-bc72-21e634af7ef1)
