### PR TITLE
feat: get user by id

### DIFF
--- a/src/modules/user/dto/get-user-data-by-id-response.dto.ts
+++ b/src/modules/user/dto/get-user-data-by-id-response.dto.ts
@@ -1,0 +1,10 @@
+import UserInterface from '../interfaces/UserInterface';
+
+export class GetUserByIdResponseDto {
+  status_code: 200;
+  user: Omit<Partial<UserInterface>, 'password'>;
+
+  constructor(user: Omit<Partial<UserInterface>, 'password'>) {
+    this.user = user;
+  }
+}

--- a/src/modules/user/tests/user.service.spec.ts
+++ b/src/modules/user/tests/user.service.spec.ts
@@ -258,4 +258,27 @@ describe('UserService', () => {
       expect(mockUserRepository.save).not.toHaveBeenCalled();
     });
   });
+
+  describe('getUserByDataByIdWithoutPassword', () => {
+    const userId = 'valid-id';
+    const userWithoutPassword = {
+      id: userId,
+      first_name: 'John',
+      last_name: 'Doe',
+      email: 'test@example.com',
+      is_active: true,
+    };
+
+    it('should return user data without password', async () => {
+      mockUserRepository.findOne.mockResolvedValueOnce({ password: 'hashedpassword', ...userWithoutPassword });
+
+      const result = await service.getUserDataWithoutPasswordById(userId);
+
+      expect(result.user).toEqual(userWithoutPassword);
+      expect(result.user).not.toHaveProperty('password');
+      expect(mockUserRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+      });
+    });
+  });
 });

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Patch, Param, Body, UsePipes, ValidationPipe, Request, Req } from '@nestjs/common';
+import { Controller, Patch, Param, Body, UsePipes, ValidationPipe, Request, Req, Get } from '@nestjs/common';
 import UserService from './user.service';
 import { UpdateUserDto } from './dto/update-user-dto';
 import { UserPayload } from './interfaces/user-payload.interface';
@@ -44,5 +44,15 @@ export class UserController {
       status_code: 200,
       message: result.message,
     };
+  }
+
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get User Data' })
+  @ApiResponse({ status: 200, description: 'User data fetched successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 500, description: 'Internal Server Error' })
+  @Get(':userId')
+  async getUserDataById(@Param('userId') userId: string) {
+    return this.userService.getUserDataWithoutPasswordById(userId);
   }
 }

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -51,8 +51,8 @@ export class UserController {
   @ApiResponse({ status: 200, description: 'User data fetched successfully' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 500, description: 'Internal Server Error' })
-  @Get(':userId')
-  async getUserDataById(@Param('userId') userId: string) {
-    return this.userService.getUserDataWithoutPasswordById(userId);
+  @Get(':id')
+  async getUserDataById(@Param('id') id: string) {
+    return this.userService.getUserDataWithoutPasswordById(id);
   }
 }

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -39,6 +39,17 @@ export default class UserService {
     await this.userRepository.save(user);
   }
 
+  async getUserDataWithoutPasswordById(id: string) {
+    const user = await this.getUserRecord({ identifier: id, identifierType: 'id' });
+
+    const { password, ...userData } = user;
+
+    return {
+      status_code: 200,
+      user: userData,
+    };
+  }
+
   private async getUserByEmail(email: string) {
     const user: UserResponseDTO = await this.userRepository.findOne({ where: { email: email } });
     return user;


### PR DESCRIPTION
## What does the PR do?
This PR is about getting a user by Id

## How should this be manually tested?
Send a GET request to `/api/v1/users/:userId` with access token in the authorization header.

## Checklist of what you did
- [x] Implemented endpoint to get a user by the `user_id`.
- [x] Handle error for invalid user id in the params.
- [x] Integrate with auth guard to prevent request from unauthorized access.
- [x] Implement safety measure to avoid leak of user sensitive data such as password.
- [x] Requests to the endpoint must include a valid authentication token in the Authorization header.
- [x] Returned success `status_code ` with the user data.
- [x] Unit test the user service to ensure it works as expected.

## Test Screenshot

![image](https://github.com/user-attachments/assets/5d809fa7-0780-4910-9a78-1e67dbf88518)

## Linked issue
#81 
