### PR TITLE
fix: change endpoint urls for login with magic link

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -61,7 +61,7 @@ export default class RegistrationController {
   }
 
   @skipAuth()
-  @Post('signin-token')
+  @Post('magic-link')
   @HttpCode(200)
   @ApiOperation({ summary: 'Request Signin Token' })
   @ApiResponse({ status: 200, description: 'Sign-in token sent to email', type: RequestSigninTokenDto })
@@ -70,7 +70,7 @@ export default class RegistrationController {
     return await this.authService.requestSignInToken(body);
   }
 
-  @Post('verify-signin-token')
+  @Post('magic-link/verify')
   @HttpCode(200)
   @ApiOperation({ summary: 'Verify Signin Token' })
   @ApiResponse({ status: 200, description: 'Sign-in successful', type: OtpDto })


### PR DESCRIPTION
# What does this PR do
This PR changes the intial endpoint for signing with magic link feature from signin-token and verify-signin-token to magic-link and magic-link/verify respectively. This is to comply with the generally agreed url specifications for all endpoint by the team starlight backend developers.