### PR TITLE
feat: mark single notification as read

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2657,12 +2657,6 @@
         "typescript": ">=4.8.2"
       }
     },
-    "node_modules/@nestjs/schematics/node_modules/jsonc-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-      "dev": true
-    },
     "node_modules/@nestjs/schematics/node_modules/@angular-devkit/schematics": {
       "version": "17.3.8",
       "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.3.8.tgz",
@@ -2703,18 +2697,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@nestjs/schematics/node_modules/picomatch": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.1.tgz",
-      "integrity": "sha512-xUXwsxNjwTQ8K3GnT4pCJm+xq3RUPQbmkYJTP5aFIfNIvbcc/4MUxgBaaRSZJ6yGJZiGSyYlM6MzwTsRk8SYCg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@nestjs/swagger": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2663,6 +2663,60 @@
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "dev": true
     },
+    "node_modules/@nestjs/schematics/node_modules/@angular-devkit/schematics": {
+      "version": "17.3.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.3.8.tgz",
+      "integrity": "sha512-QRVEYpIfgkprNHc916JlPuNbLzOgrm9DZalHasnLUz4P6g7pR21olb8YCyM2OTJjombNhya9ZpckcADU5Qyvlg==",
+      "dev": true,
+      "dependencies": {
+        "@angular-devkit/core": "17.3.8",
+        "jsonc-parser": "3.2.1",
+        "magic-string": "0.30.8",
+        "ora": "5.4.1",
+        "rxjs": "7.8.1"
+      },
+      "engines": {
+        "node": "^18.13.0 || >=20.9.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@nestjs/schematics/node_modules/@angular-devkit/schematics/node_modules/jsonc-parser": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
+      "dev": true
+    },
+    "node_modules/@nestjs/schematics/node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true
+    },
+    "node_modules/@nestjs/schematics/node_modules/magic-string": {
+      "version": "0.30.8",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
+      "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@nestjs/schematics/node_modules/picomatch": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.1.tgz",
+      "integrity": "sha512-xUXwsxNjwTQ8K3GnT4pCJm+xq3RUPQbmkYJTP5aFIfNIvbcc/4MUxgBaaRSZJ6yGJZiGSyYlM6MzwTsRk8SYCg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@nestjs/swagger": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.4.0.tgz",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -29,6 +29,7 @@ import { TimezonesModule } from './modules/timezones/timezones.module';
 import { UserModule } from './modules/user/user.module';
 import ProbeController from './probe.controller';
 import { RunTestsModule } from './run-tests/run-tests.module';
+import { NotificationsModule } from './modules/notifications/notifications.module';
 
 @Module({
   providers: [
@@ -119,6 +120,7 @@ import { RunTestsModule } from './run-tests/run-tests.module';
     JobsModule,
     ProfileModule,
     RunTestsModule,
+    NotificationsModule,
   ],
   controllers: [HealthController, ProbeController],
 })

--- a/src/database/seeding/seeding.service.ts
+++ b/src/database/seeding/seeding.service.ts
@@ -6,6 +6,7 @@ import { Invite } from '../../modules/invite/entities/invite.entity';
 import { Product } from '../../modules/products/entities/product.entity';
 import { ProductCategory } from '../../modules/product-category/entities/product-category.entity';
 import { Profile } from '../../modules/profile/entities/profile.entity';
+import { Notification } from '../../modules/notifications/entities/notifications.entity';
 
 @Injectable()
 export class SeedingService {
@@ -18,6 +19,7 @@ export class SeedingService {
     const organisationRepository = this.dataSource.getRepository(Organisation);
     const productRepository = this.dataSource.getRepository(Product);
     const categoryRepository = this.dataSource.getRepository(ProductCategory);
+    const notificationRepository = this.dataSource.getRepository(Notification);
 
     try {
       const existingUsers = await userRepository.count();
@@ -165,6 +167,31 @@ export class SeedingService {
         const savedCategories = await categoryRepository.find({ relations: ['products'] });
         if (savedCategories.length !== 3) {
           throw new Error('Failed to create all categories');
+        }
+
+        const notifications = [
+          notificationRepository.create({
+            message: 'Notification 1 for John',
+            user: savedUsers[0],
+          }),
+          notificationRepository.create({
+            message: 'Notification 2 for John',
+            user: savedUsers[0],
+          }),
+          notificationRepository.create({
+            message: 'Notification 1 for Jane',
+            user: savedUsers[1],
+          }),
+          notificationRepository.create({
+            message: 'Notification 2 for Jane',
+            user: savedUsers[1],
+          }),
+        ];
+
+        await notificationRepository.save(notifications);
+        const savedNotifications = await notificationRepository.find();
+        if (savedNotifications.length !== 4) {
+          throw new Error('Failed to create all notifications');
         }
 
         await queryRunner.commitTransaction();

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,8 +30,8 @@ async function bootstrap() {
   app.enable('trust proxy');
   app.useLogger(logger);
   app.enableCors();
-  app.setGlobalPrefix('api/v1', { exclude: ['/', 'run-tests', 'health', 'api', 'api/v1', 'api/docs', 'probe'] });
-  app.useGlobalInterceptors(new ResponseInterceptor());
+  app.setGlobalPrefix('api/v1', { exclude: ['/', 'health', 'api', 'api/v1', 'api/docs', 'probe'] });
+  // app.useGlobalInterceptors(new ResponseInterceptor());
 
   // TODO: set options for swagger docs
   const options = new DocumentBuilder()

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,7 @@ async function bootstrap() {
   app.useLogger(logger);
   app.enableCors();
   app.setGlobalPrefix('api/v1', { exclude: ['/', 'health', 'api', 'api/v1', 'api/docs', 'probe'] });
-  // app.useGlobalInterceptors(new ResponseInterceptor());
+  app.useGlobalInterceptors(new ResponseInterceptor());
 
   // TODO: set options for swagger docs
   const options = new DocumentBuilder()

--- a/src/modules/invite/tests/invite.service.spec.ts
+++ b/src/modules/invite/tests/invite.service.spec.ts
@@ -50,6 +50,8 @@ describe('InviteService', () => {
       testimonials: [],
       profile: null,
       organisationMembers: [],
+      products: [],
+      notifications: [],
     };
 
     const mockOrg: Organisation = {

--- a/src/modules/invite/tests/invite.service.spec.ts
+++ b/src/modules/invite/tests/invite.service.spec.ts
@@ -50,7 +50,6 @@ describe('InviteService', () => {
       testimonials: [],
       profile: null,
       organisationMembers: [],
-      products: [],
       notifications: [],
     };
 

--- a/src/modules/jobs/tests/job.service.spec.ts
+++ b/src/modules/jobs/tests/job.service.spec.ts
@@ -36,6 +36,7 @@ describe('JobsService', () => {
     created_at: new Date(),
     updated_at: new Date(),
     hashPassword: () => null,
+    notifications: [],
   };
 
   const mockJob: Job = {

--- a/src/modules/notifications/dtos/create-notification-response.dto.ts
+++ b/src/modules/notifications/dtos/create-notification-response.dto.ts
@@ -1,0 +1,24 @@
+import { IsString } from 'class-validator';
+
+class Data {
+  notifications: ResponseNotification[];
+}
+
+export class CreateNotificationResponseDto {
+  @IsString()
+  status: string;
+  @IsString()
+  message: string;
+  @IsString()
+  status_code: number;
+  @IsString()
+  data: Data;
+}
+
+class ResponseNotification {
+  notification_id: string;
+  user_id: string;
+  message: string;
+  is_read: boolean;
+  created_at: string | Date;
+}

--- a/src/modules/notifications/dtos/create-notification-response.dto.ts
+++ b/src/modules/notifications/dtos/create-notification-response.dto.ts
@@ -1,24 +1,8 @@
-import { IsString } from 'class-validator';
-
-class Data {
-  notifications: ResponseNotification[];
-}
+import { NotificationData } from './notification-data.dto';
 
 export class CreateNotificationResponseDto {
-  @IsString()
   status: string;
-  @IsString()
   message: string;
-  @IsString()
   status_code: number;
-  @IsString()
-  data: Data;
-}
-
-class ResponseNotification {
-  notification_id: string;
-  user_id: string;
-  message: string;
-  is_read: boolean;
-  created_at: string | Date;
+  data: NotificationData;
 }

--- a/src/modules/notifications/dtos/mark-notification-as-read-error.dto.ts
+++ b/src/modules/notifications/dtos/mark-notification-as-read-error.dto.ts
@@ -1,0 +1,6 @@
+export class MarkNotificationAsReadErrorDto {
+  status: boolean;
+  status_code: number;
+  error: string;
+  message: string;
+}

--- a/src/modules/notifications/dtos/mark-notification-as-read.dto.ts
+++ b/src/modules/notifications/dtos/mark-notification-as-read.dto.ts
@@ -3,5 +3,5 @@ import { IsBoolean, IsNotEmpty } from 'class-validator';
 export class MarkNotificationAsReadDto {
   @IsBoolean()
   @IsNotEmpty()
-  isRead: boolean;
+  is_read: boolean;
 }

--- a/src/modules/notifications/dtos/mark-notification-as-read.dto.ts
+++ b/src/modules/notifications/dtos/mark-notification-as-read.dto.ts
@@ -1,6 +1,7 @@
-import { IsBoolean } from 'class-validator';
+import { IsBoolean, IsNotEmpty } from 'class-validator';
 
 export class MarkNotificationAsReadDto {
   @IsBoolean()
+  @IsNotEmpty()
   isRead: boolean;
 }

--- a/src/modules/notifications/dtos/mark-notification-as-read.dto.ts
+++ b/src/modules/notifications/dtos/mark-notification-as-read.dto.ts
@@ -1,0 +1,6 @@
+import { IsBoolean } from 'class-validator';
+
+export class MarkNotificationAsReadDto {
+  @IsBoolean()
+  isRead: boolean;
+}

--- a/src/modules/notifications/dtos/notification-data.dto.ts
+++ b/src/modules/notifications/dtos/notification-data.dto.ts
@@ -1,0 +1,5 @@
+import { ResponseNotification } from './notification-response.dto';
+
+export class NotificationData {
+  notifications: ResponseNotification[];
+}

--- a/src/modules/notifications/dtos/notification-response.dto.ts
+++ b/src/modules/notifications/dtos/notification-response.dto.ts
@@ -1,0 +1,7 @@
+export class ResponseNotification {
+  notification_id: string;
+  user_id: string;
+  message: string;
+  is_read: boolean;
+  created_at: string | Date;
+}

--- a/src/modules/notifications/entities/notifications.entity.ts
+++ b/src/modules/notifications/entities/notifications.entity.ts
@@ -1,0 +1,15 @@
+import { AbstractBaseEntity } from '../../../entities/base.entity';
+import { User } from '../../user/entities/user.entity';
+import { Column, Entity, ManyToOne } from 'typeorm';
+
+@Entity({ name: 'notifications' })
+export class Notification extends AbstractBaseEntity {
+  @Column({ nullable: false })
+  message: string;
+
+  @Column({ nullable: false, default: false })
+  isRead: boolean;
+
+  @ManyToOne(() => User, user => user.notifications)
+  user: User;
+}

--- a/src/modules/notifications/entities/notifications.entity.ts
+++ b/src/modules/notifications/entities/notifications.entity.ts
@@ -2,7 +2,7 @@ import { AbstractBaseEntity } from '../../../entities/base.entity';
 import { User } from '../../user/entities/user.entity';
 import { Column, Entity, ManyToOne } from 'typeorm';
 
-@Entity({ name: 'notifications' })
+@Entity()
 export class Notification extends AbstractBaseEntity {
   @Column({ nullable: false })
   message: string;

--- a/src/modules/notifications/entities/notifications.entity.ts
+++ b/src/modules/notifications/entities/notifications.entity.ts
@@ -8,8 +8,8 @@ export class Notification extends AbstractBaseEntity {
   message: string;
 
   @Column({ nullable: false, default: false })
-  isRead: boolean;
+  is_read: boolean;
 
-  @ManyToOne(() => User, user => user.notifications)
+  @ManyToOne(() => User, user => user.notifications, { nullable: false, onDelete: 'CASCADE' })
   user: User;
 }

--- a/src/modules/notifications/notifications.controller.ts
+++ b/src/modules/notifications/notifications.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Param, Patch, Req, Request, ValidationPipe } from '@nestjs/common';
 import { NotificationsService } from './notifications.service';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { MarkNotificationAsReadDto } from './dtos/mark-notification-as-read.dto';
 
 @ApiBearerAuth()
@@ -10,6 +10,12 @@ export class NotificationsController {
   constructor(private readonly notificationsService: NotificationsService) {}
 
   @Patch('/:notificationId/read')
+  @ApiBody({ type: MarkNotificationAsReadDto, description: 'Read status of the notification' })
+  @ApiResponse({ status: 200, description: 'Notification marked as read successfully' })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  @ApiResponse({ status: 400, description: 'Bad request' })
+  @ApiResponse({ status: 400, description: 'Notification not found' })
+  @ApiOperation({ summary: 'Marks a single notification as read' })
   async markNotificationAsRead(
     @Param('notificationId') notification_id: string,
     @Body() markNotificationAsRead: MarkNotificationAsReadDto,

--- a/src/modules/notifications/notifications.controller.ts
+++ b/src/modules/notifications/notifications.controller.ts
@@ -11,13 +11,13 @@ export class NotificationsController {
 
   @Patch('/:notificationId/read')
   async markNotificationAsRead(
-    @Param('notificationId') notificationId: string,
+    @Param('notificationId') notification_id: string,
     @Body() markNotificationAsRead: MarkNotificationAsReadDto,
     @Req() request: Request
   ) {
     const user = request['user'];
 
     const userId = user.id;
-    return this.notificationsService.markNotificationAsRead(markNotificationAsRead, notificationId, userId);
+    return this.notificationsService.markNotificationAsRead(markNotificationAsRead, notification_id, userId);
   }
 }

--- a/src/modules/notifications/notifications.controller.ts
+++ b/src/modules/notifications/notifications.controller.ts
@@ -1,8 +1,9 @@
 import { Body, Controller, Param, Patch, Req, Request, ValidationPipe } from '@nestjs/common';
 import { NotificationsService } from './notifications.service';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { MarkNotificationAsReadDto } from './dtos/mark-notification-as-read.dto';
 
+@ApiBearerAuth()
 @ApiTags('Notification')
 @Controller('notifications')
 export class NotificationsController {
@@ -11,7 +12,7 @@ export class NotificationsController {
   @Patch('/:notificationId/read')
   async markNotificationAsRead(
     @Param('notificationId') notificationId: string,
-    @Body(ValidationPipe) markNotificationAsRead: MarkNotificationAsReadDto,
+    @Body() markNotificationAsRead: MarkNotificationAsReadDto,
     @Req() request: Request
   ) {
     const user = request['user'];

--- a/src/modules/notifications/notifications.controller.ts
+++ b/src/modules/notifications/notifications.controller.ts
@@ -1,7 +1,19 @@
 import { Body, Controller, Param, Patch, Req, Request, ValidationPipe } from '@nestjs/common';
 import { NotificationsService } from './notifications.service';
-import { ApiBearerAuth, ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiBody,
+  ApiCreatedResponse,
+  ApiInternalServerErrorResponse,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 import { MarkNotificationAsReadDto } from './dtos/mark-notification-as-read.dto';
+import { CreateNotificationResponseDto } from './dtos/create-notification-response.dto';
+import { MarkNotificationAsReadErrorDto } from './dtos/mark-notification-as-read-error.dto';
 
 @ApiBearerAuth()
 @ApiTags('Notification')
@@ -9,12 +21,12 @@ import { MarkNotificationAsReadDto } from './dtos/mark-notification-as-read.dto'
 export class NotificationsController {
   constructor(private readonly notificationsService: NotificationsService) {}
 
-  @Patch('/:notificationId/read')
+  @Patch('/:notificationId')
   @ApiBody({ type: MarkNotificationAsReadDto, description: 'Read status of the notification' })
-  @ApiResponse({ status: 200, description: 'Notification marked as read successfully' })
-  @ApiResponse({ status: 500, description: 'Internal server error' })
-  @ApiResponse({ status: 400, description: 'Bad request' })
-  @ApiResponse({ status: 400, description: 'Notification not found' })
+  @ApiCreatedResponse({ type: CreateNotificationResponseDto, description: 'Notification created successfully' })
+  @ApiUnauthorizedResponse({ type: MarkNotificationAsReadErrorDto, description: 'Unauthorized' })
+  @ApiBadRequestResponse({ type: MarkNotificationAsReadErrorDto, description: 'Bad Request' })
+  @ApiInternalServerErrorResponse({ type: MarkNotificationAsReadErrorDto, description: 'Internal Server Error' })
   @ApiOperation({ summary: 'Marks a single notification as read' })
   async markNotificationAsRead(
     @Param('notificationId') notification_id: string,

--- a/src/modules/notifications/notifications.controller.ts
+++ b/src/modules/notifications/notifications.controller.ts
@@ -4,8 +4,8 @@ import {
   ApiBadRequestResponse,
   ApiBearerAuth,
   ApiBody,
-  ApiCreatedResponse,
   ApiInternalServerErrorResponse,
+  ApiOkResponse,
   ApiOperation,
   ApiResponse,
   ApiTags,
@@ -23,7 +23,7 @@ export class NotificationsController {
 
   @Patch('/:notificationId')
   @ApiBody({ type: MarkNotificationAsReadDto, description: 'Read status of the notification' })
-  @ApiCreatedResponse({ type: CreateNotificationResponseDto, description: 'Notification created successfully' })
+  @ApiOkResponse({ type: CreateNotificationResponseDto, description: 'Notification created successfully' })
   @ApiUnauthorizedResponse({ type: MarkNotificationAsReadErrorDto, description: 'Unauthorized' })
   @ApiBadRequestResponse({ type: MarkNotificationAsReadErrorDto, description: 'Bad Request' })
   @ApiInternalServerErrorResponse({ type: MarkNotificationAsReadErrorDto, description: 'Internal Server Error' })

--- a/src/modules/notifications/notifications.controller.ts
+++ b/src/modules/notifications/notifications.controller.ts
@@ -1,0 +1,22 @@
+import { Body, Controller, Param, Patch, Req, Request, ValidationPipe } from '@nestjs/common';
+import { NotificationsService } from './notifications.service';
+import { ApiTags } from '@nestjs/swagger';
+import { MarkNotificationAsReadDto } from './dtos/mark-notification-as-read.dto';
+
+@ApiTags('Notification')
+@Controller('notifications')
+export class NotificationsController {
+  constructor(private readonly notificationsService: NotificationsService) {}
+
+  @Patch('/:notificationId/read')
+  async markNotificationAsRead(
+    @Param('notificationId') notificationId: string,
+    @Body(ValidationPipe) markNotificationAsRead: MarkNotificationAsReadDto,
+    @Req() request: Request
+  ) {
+    const user = request['user'];
+
+    const userId = user.id;
+    return this.notificationsService.markNotificationAsRead(markNotificationAsRead, notificationId, userId);
+  }
+}

--- a/src/modules/notifications/notifications.module.ts
+++ b/src/modules/notifications/notifications.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { NotificationsService } from './notifications.service';
+import { NotificationsController } from './notifications.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Notification } from './entities/notifications.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Notification])],
+  controllers: [NotificationsController],
+  providers: [NotificationsService],
+})
+export class NotificationsModule {}

--- a/src/modules/notifications/notifications.service.ts
+++ b/src/modules/notifications/notifications.service.ts
@@ -11,9 +11,9 @@ export class NotificationsService {
     private readonly notificationRepository: Repository<Notification>
   ) {}
 
-  async markNotificationAsRead(options: MarkNotificationAsReadDto, notificationId: string, userId: string) {
+  async markNotificationAsRead(options: MarkNotificationAsReadDto, notification_id: string, userId: string) {
     try {
-      if (!notificationId || !options) {
+      if (!notification_id || !options) {
         throw new BadRequestException({
           status: 'error',
           message: 'Invalid Request',
@@ -22,7 +22,7 @@ export class NotificationsService {
       }
 
       const notificationExists = await this.notificationRepository.findOne({
-        where: { id: notificationId },
+        where: { id: notification_id },
         relations: ['user'],
       });
 
@@ -37,20 +37,17 @@ export class NotificationsService {
         );
       }
 
-      if (notificationExists.user.id !== userId) {
-        throw new ForbiddenException('You do not have permission to access this notification');
-      }
-
-      notificationExists.isRead = options.isRead;
+      notificationExists.isRead = options.is_read;
       await this.notificationRepository.save(notificationExists);
 
       return {
         status: 'success',
         message: 'Notification marked as read successfully',
+        status_code: HttpStatus.OK,
         data: {
-          id: notificationExists.id,
+          notification_id: notificationExists.id,
           message: notificationExists.message,
-          isRead: notificationExists.isRead,
+          is_read: notificationExists.isRead,
           updatedAt: notificationExists.updated_at,
         },
       };

--- a/src/modules/notifications/notifications.service.ts
+++ b/src/modules/notifications/notifications.service.ts
@@ -31,7 +31,6 @@ export class NotificationsService {
 
       const notificationExists = await this.notificationRepository.findOne({
         where: { id: notificationId },
-        relations: ['user'],
       });
 
       if (!notificationExists) {
@@ -42,10 +41,10 @@ export class NotificationsService {
         });
       }
 
-      notificationExists.isRead = options.is_read;
+      notificationExists.is_read = options.is_read;
       await this.notificationRepository.save(notificationExists);
 
-      const { id: notification_id, message, isRead: is_read, updated_at } = notificationExists;
+      const { id: notification_id, message, is_read, updated_at } = notificationExists;
 
       return {
         status: 'success',

--- a/src/modules/notifications/notifications.service.ts
+++ b/src/modules/notifications/notifications.service.ts
@@ -1,0 +1,57 @@
+import { BadRequestException, ForbiddenException, HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Notification } from './entities/notifications.entity';
+import { MarkNotificationAsReadDto } from './dtos/mark-notification-as-read.dto';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class NotificationsService {
+  constructor(
+    @InjectRepository(Notification)
+    private readonly notificationRepository: Repository<Notification>
+  ) {}
+
+  async markNotificationAsRead(options: MarkNotificationAsReadDto, notificationId: string, userId: string) {
+    if (!notificationId || !options) {
+      throw new BadRequestException({
+        status: 'error',
+        message: 'Invalid Request',
+        status_code: HttpStatus.BAD_REQUEST,
+      });
+    }
+
+    const notificationExists = await this.notificationRepository.findOne({
+      where: { id: notificationId },
+      relations: ['user'],
+    });
+
+    if (!notificationExists) {
+      throw new HttpException(
+        {
+          status: 'error',
+          message: 'Notification not found',
+          status_code: HttpStatus.NOT_FOUND,
+        },
+        HttpStatus.NOT_FOUND
+      );
+    }
+
+    if (notificationExists.user.id !== userId) {
+      throw new ForbiddenException('You do not have permission to access this notification');
+    }
+
+    notificationExists.isRead = options.isRead;
+    await this.notificationRepository.save(notificationExists);
+
+    return {
+      status: 'success',
+      message: 'Notification marked as read successfully',
+      data: {
+        id: notificationExists.id,
+        message: notificationExists.message,
+        isRead: notificationExists.isRead,
+        updatedAt: notificationExists.updated_at,
+      },
+    };
+  }
+}

--- a/src/modules/notifications/notifications.service.ts
+++ b/src/modules/notifications/notifications.service.ts
@@ -5,6 +5,7 @@ import {
   HttpStatus,
   Injectable,
   InternalServerErrorException,
+  NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Notification } from './entities/notifications.entity';
@@ -18,9 +19,9 @@ export class NotificationsService {
     private readonly notificationRepository: Repository<Notification>
   ) {}
 
-  async markNotificationAsRead(options: MarkNotificationAsReadDto, notification_id: string, userId: string) {
+  async markNotificationAsRead(options: MarkNotificationAsReadDto, notificationId: string, userId: string) {
     try {
-      if (!notification_id || !options) {
+      if (!notificationId || !options) {
         throw new BadRequestException({
           status: 'error',
           message: 'Invalid Request',
@@ -29,37 +30,40 @@ export class NotificationsService {
       }
 
       const notificationExists = await this.notificationRepository.findOne({
-        where: { id: notification_id },
+        where: { id: notificationId },
         relations: ['user'],
       });
 
       if (!notificationExists) {
-        throw new HttpException(
-          {
-            status: 'error',
-            message: 'Notification not found',
-            status_code: HttpStatus.NOT_FOUND,
-          },
-          HttpStatus.NOT_FOUND
-        );
+        throw new NotFoundException({
+          status: 'error',
+          message: 'Notification not found',
+          status_code: HttpStatus.NOT_FOUND,
+        });
       }
 
       notificationExists.isRead = options.is_read;
       await this.notificationRepository.save(notificationExists);
+
+      const { id: notification_id, message, isRead: is_read, updated_at } = notificationExists;
 
       return {
         status: 'success',
         message: 'Notification marked as read successfully',
         status_code: HttpStatus.OK,
         data: {
-          notification_id: notificationExists.id,
-          message: notificationExists.message,
-          is_read: notificationExists.isRead,
-          updatedAt: notificationExists.updated_at,
+          notification_id,
+          message,
+          is_read,
+          updated_at,
         },
       };
     } catch (error) {
-      if (error instanceof HttpException) {
+      if (
+        error instanceof HttpException ||
+        error instanceof BadRequestException ||
+        error instanceof NotFoundException
+      ) {
         throw error;
       } else {
         throw new InternalServerErrorException();

--- a/src/modules/notifications/notifications.service.ts
+++ b/src/modules/notifications/notifications.service.ts
@@ -1,4 +1,11 @@
-import { BadRequestException, ForbiddenException, HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  HttpException,
+  HttpStatus,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Notification } from './entities/notifications.entity';
 import { MarkNotificationAsReadDto } from './dtos/mark-notification-as-read.dto';
@@ -55,15 +62,7 @@ export class NotificationsService {
       if (error instanceof HttpException) {
         throw error;
       } else {
-        console.error('An unexpected error ocurred', error);
-        throw new HttpException(
-          {
-            status: 'error',
-            message: 'An unexpected error ocurred',
-            status_code: HttpStatus.INTERNAL_SERVER_ERROR,
-          },
-          HttpStatus.INTERNAL_SERVER_ERROR
-        );
+        throw new InternalServerErrorException();
       }
     }
   }

--- a/src/modules/notifications/notifications.service.ts
+++ b/src/modules/notifications/notifications.service.ts
@@ -12,46 +12,62 @@ export class NotificationsService {
   ) {}
 
   async markNotificationAsRead(options: MarkNotificationAsReadDto, notificationId: string, userId: string) {
-    if (!notificationId || !options) {
-      throw new BadRequestException({
-        status: 'error',
-        message: 'Invalid Request',
-        status_code: HttpStatus.BAD_REQUEST,
-      });
-    }
-
-    const notificationExists = await this.notificationRepository.findOne({
-      where: { id: notificationId },
-      relations: ['user'],
-    });
-
-    if (!notificationExists) {
-      throw new HttpException(
-        {
+    try {
+      if (!notificationId || !options) {
+        throw new BadRequestException({
           status: 'error',
-          message: 'Notification not found',
-          status_code: HttpStatus.NOT_FOUND,
+          message: 'Invalid Request',
+          status_code: HttpStatus.BAD_REQUEST,
+        });
+      }
+
+      const notificationExists = await this.notificationRepository.findOne({
+        where: { id: notificationId },
+        relations: ['user'],
+      });
+
+      if (!notificationExists) {
+        throw new HttpException(
+          {
+            status: 'error',
+            message: 'Notification not found',
+            status_code: HttpStatus.NOT_FOUND,
+          },
+          HttpStatus.NOT_FOUND
+        );
+      }
+
+      if (notificationExists.user.id !== userId) {
+        throw new ForbiddenException('You do not have permission to access this notification');
+      }
+
+      notificationExists.isRead = options.isRead;
+      await this.notificationRepository.save(notificationExists);
+
+      return {
+        status: 'success',
+        message: 'Notification marked as read successfully',
+        data: {
+          id: notificationExists.id,
+          message: notificationExists.message,
+          isRead: notificationExists.isRead,
+          updatedAt: notificationExists.updated_at,
         },
-        HttpStatus.NOT_FOUND
-      );
+      };
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      } else {
+        console.error('An unexpected error ocurred', error);
+        throw new HttpException(
+          {
+            status: 'error',
+            message: 'An unexpected error ocurred',
+            status_code: HttpStatus.INTERNAL_SERVER_ERROR,
+          },
+          HttpStatus.INTERNAL_SERVER_ERROR
+        );
+      }
     }
-
-    if (notificationExists.user.id !== userId) {
-      throw new ForbiddenException('You do not have permission to access this notification');
-    }
-
-    notificationExists.isRead = options.isRead;
-    await this.notificationRepository.save(notificationExists);
-
-    return {
-      status: 'success',
-      message: 'Notification marked as read successfully',
-      data: {
-        id: notificationExists.id,
-        message: notificationExists.message,
-        isRead: notificationExists.isRead,
-        updatedAt: notificationExists.updated_at,
-      },
-    };
   }
 }

--- a/src/modules/notifications/tests/mocks/notification-repo.mock.ts
+++ b/src/modules/notifications/tests/mocks/notification-repo.mock.ts
@@ -1,9 +1,15 @@
 import { User, UserType } from '../../../user/entities/user.entity';
-import { v4 as uuidv4 } from 'uuid';
 
-export const updateNotificationMock = {
-  findOne: jest.fn(),
-  save: jest.fn(),
+export const mockNotificationRepository = {
+  find: jest.fn().mockResolvedValue([]),
+  findOne: jest.fn().mockResolvedValue(null),
+  save: jest.fn().mockResolvedValue({}),
+  createQueryBuilder: jest.fn(() => ({
+    delete: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    execute: jest.fn().mockResolvedValue({}),
+  })),
 };
 
 export const mockUser: User = {

--- a/src/modules/notifications/tests/mocks/notification-repo.mock.ts
+++ b/src/modules/notifications/tests/mocks/notification-repo.mock.ts
@@ -1,3 +1,4 @@
+import { Profile } from '../../../profile/entities/profile.entity';
 import { User, UserType } from '../../../user/entities/user.entity';
 
 export const mockNotificationRepository = {
@@ -10,6 +11,24 @@ export const mockNotificationRepository = {
     where: jest.fn().mockReturnThis(),
     execute: jest.fn().mockResolvedValue({}),
   })),
+};
+
+const profileMock: Profile = {
+  id: 'some-uuid',
+  username: 'mockuser',
+  jobTitle: 'Developer',
+  pronouns: 'They/Them',
+  department: 'Engineering',
+  email: 'mockuser@example.com',
+  bio: 'A mock user for testing purposes',
+  social_links: [],
+  language: 'English',
+  region: 'US',
+  timezones: 'America/New_York',
+  profile_pic_url: '',
+  created_at: new Date(),
+  updated_at: new Date(),
+  user_id: null,
 };
 
 export const mockUser: User = {
@@ -32,5 +51,6 @@ export const mockUser: User = {
   secret: 'secret',
   is_2fa_enabled: false,
   notifications: [],
-  products: [],
+  organisationMembers: [],
+  profile: profileMock,
 };

--- a/src/modules/notifications/tests/mocks/notification-repo.mock.ts
+++ b/src/modules/notifications/tests/mocks/notification-repo.mock.ts
@@ -53,4 +53,6 @@ export const mockUser: User = {
   notifications: [],
   organisationMembers: [],
   profile: profileMock,
+  phone: '1234-887-09',
+  jobs: [],
 };

--- a/src/modules/notifications/tests/mocks/notification-repo.mock.ts
+++ b/src/modules/notifications/tests/mocks/notification-repo.mock.ts
@@ -53,4 +53,6 @@ export const mockUser: User = {
   notifications: [],
   organisationMembers: [],
   profile: profileMock,
+  phone: '09087653456',
+  jobs: [],
 };

--- a/src/modules/notifications/tests/mocks/notification-repo.mock.ts
+++ b/src/modules/notifications/tests/mocks/notification-repo.mock.ts
@@ -53,6 +53,4 @@ export const mockUser: User = {
   notifications: [],
   organisationMembers: [],
   profile: profileMock,
-  phone: '09087653456',
-  jobs: [],
 };

--- a/src/modules/notifications/tests/mocks/update-notification-to-isRead.ts
+++ b/src/modules/notifications/tests/mocks/update-notification-to-isRead.ts
@@ -1,0 +1,29 @@
+import { User, UserType } from '../../../user/entities/user.entity';
+import { v4 as uuidv4 } from 'uuid';
+
+export const updateNotificationMock = {
+  findOne: jest.fn(),
+  save: jest.fn(),
+};
+
+export const mockUser: User = {
+  id: 'validUserId',
+  created_at: new Date(),
+  updated_at: new Date(),
+  first_name: 'John',
+  last_name: 'Smith',
+  email: 'john.smith@example.com',
+  password: 'pass123',
+  hashPassword: async () => {},
+  is_active: true,
+  attempts_left: 3,
+  time_left: 3600,
+  owned_organisations: [],
+  created_organisations: [],
+  invites: [],
+  testimonials: [],
+  user_type: UserType.ADMIN,
+  secret: 'secret',
+  is_2fa_enabled: false,
+  notifications: [],
+};

--- a/src/modules/notifications/tests/mocks/update-notification-to-isRead.ts
+++ b/src/modules/notifications/tests/mocks/update-notification-to-isRead.ts
@@ -26,4 +26,5 @@ export const mockUser: User = {
   secret: 'secret',
   is_2fa_enabled: false,
   notifications: [],
+  products: [],
 };

--- a/src/modules/notifications/tests/notifications.service.spec.ts
+++ b/src/modules/notifications/tests/notifications.service.spec.ts
@@ -1,0 +1,109 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationsService } from '../notifications.service';
+import { Repository } from 'typeorm';
+import { Notification } from '../entities/notifications.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { mockUser, updateNotificationMock } from './mocks/update-notification-to-isRead';
+import { BadRequestException, ForbiddenException, HttpStatus, NotFoundException } from '@nestjs/common';
+import { User } from '../../../modules/user/entities/user.entity';
+
+describe('NotificationsService', () => {
+  let service: NotificationsService;
+  let notificationRepository: Repository<Notification>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationsService,
+        {
+          provide: getRepositoryToken(Notification),
+          useValue: updateNotificationMock,
+        },
+      ],
+    }).compile();
+
+    service = module.get<NotificationsService>(NotificationsService);
+    notificationRepository = module.get<Repository<Notification>>(getRepositoryToken(Notification));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('markNotificationAsRead', () => {
+    const userId = 'validUserId';
+
+    it('should throw a BadRequest exception if notificationId or options are invalid', async () => {
+      await expect(service.markNotificationAsRead(null, null, userId)).rejects.toThrow(
+        new BadRequestException({
+          status: 'error',
+          message: 'Invalid Request',
+          status_code: HttpStatus.BAD_REQUEST,
+        })
+      );
+    });
+
+    it('should throw a NotFound exception if notification does not exist', async () => {
+      updateNotificationMock.findOne.mockResolvedValue(null);
+
+      await expect(service.markNotificationAsRead({ isRead: true }, 'invalid-id', userId)).rejects.toThrow(
+        new NotFoundException({
+          status: 'error',
+          message: 'Notification not found',
+          status_code: HttpStatus.NOT_FOUND,
+        })
+      );
+    });
+
+    it('should throw a ForbiddenException if notification does not belong to the user', async () => {
+      const differentUser: Partial<User> = { ...mockUser, id: 'different-user' };
+      const notification: Notification = {
+        id: 'valid-id',
+        isRead: false,
+        message: 'new Notification',
+        user: differentUser as User,
+        updated_at: new Date(),
+        created_at: new Date(),
+      };
+
+      updateNotificationMock.findOne.mockResolvedValue(notification);
+
+      await expect(service.markNotificationAsRead({ isRead: true }, 'valid-id', userId)).rejects.toThrow(
+        new ForbiddenException('You do not have permission to access this notification')
+      );
+    });
+
+    it('should mark notification as read if it exists and belongs to the user', async () => {
+      const notification: Notification = {
+        id: 'valid-id',
+        isRead: false,
+        message: 'valid notification',
+        user: mockUser as User,
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+      const options = { isRead: true };
+      updateNotificationMock.findOne.mockResolvedValue(notification);
+      updateNotificationMock.save.mockResolvedValue({ ...notification, isRead: true });
+
+      const result = await service.markNotificationAsRead(options, 'valid-id', userId);
+
+      expect(result).toEqual({
+        status: 'success',
+        message: 'Notification marked as read successfully',
+        data: {
+          id: notification.id,
+          message: notification.message,
+          isRead: notification.isRead,
+          updatedAt: notification.updated_at,
+        },
+      });
+
+      expect(updateNotificationMock.save).toHaveBeenCalledWith({ ...notification, isRead: true });
+    });
+  });
+});

--- a/src/modules/notifications/tests/notifications.service.spec.ts
+++ b/src/modules/notifications/tests/notifications.service.spec.ts
@@ -62,7 +62,7 @@ describe('NotificationsService', () => {
     it('should mark notification as read if it exists and belongs to the user', async () => {
       const notification: Notification = {
         id: 'valid-id',
-        isRead: false,
+        is_read: false,
         message: 'valid notification',
         user: mockUser as User,
         created_at: new Date(),
@@ -70,7 +70,7 @@ describe('NotificationsService', () => {
       };
       const options = { is_read: true };
       mockNotificationRepository.findOne.mockResolvedValue(notification);
-      mockNotificationRepository.save.mockResolvedValue({ ...notification, isRead: true });
+      mockNotificationRepository.save.mockResolvedValue({ ...notification, is_read: true });
 
       const result = await service.markNotificationAsRead(options, 'valid-id', userId);
 
@@ -81,12 +81,12 @@ describe('NotificationsService', () => {
         data: {
           notification_id: notification.id,
           message: notification.message,
-          is_read: notification.isRead,
+          is_read: notification.is_read,
           updated_at: notification.updated_at,
         },
       });
 
-      expect(mockNotificationRepository.save).toHaveBeenCalledWith({ ...notification, isRead: true });
+      expect(mockNotificationRepository.save).toHaveBeenCalledWith({ ...notification, is_read: true });
     });
   });
 });

--- a/src/modules/notifications/tests/notifications.service.spec.ts
+++ b/src/modules/notifications/tests/notifications.service.spec.ts
@@ -82,7 +82,7 @@ describe('NotificationsService', () => {
           notification_id: notification.id,
           message: notification.message,
           is_read: notification.isRead,
-          updatedAt: notification.updated_at,
+          updated_at: notification.updated_at,
         },
       });
 

--- a/src/modules/organisations/tests/mocks/organisation.mock.ts
+++ b/src/modules/organisations/tests/mocks/organisation.mock.ts
@@ -62,6 +62,7 @@ export const createMockOrganisation = (): Organisation => {
     products: [],
     profile: profileMock,
     organisationMembers: [orgMemberMock],
+    notifications: [],
   };
 
   return {

--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -82,9 +82,6 @@ export class User extends AbstractBaseEntity {
     this.password = await bcrypt.hash(this.password, 10);
   }
 
-  @OneToMany(() => Testimonial, testimonial => testimonial.user)
-  testimonials: Testimonial[];
-
   @OneToMany(() => Notification, notification => notification.user)
   notifications: Notification[];
 }

--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -8,6 +8,7 @@ import { Product } from '../../../modules/products/entities/product.entity';
 import { Job } from '../../../modules/jobs/entities/job.entity';
 import { Profile } from '../../profile/entities/profile.entity';
 import { OrganisationMember } from '../../organisations/entities/org-members.entity';
+import { Notification } from '../../notifications/entities/notifications.entity';
 
 export enum UserType {
   SUPER_ADMIN = 'super-admin',
@@ -80,4 +81,10 @@ export class User extends AbstractBaseEntity {
   async hashPassword() {
     this.password = await bcrypt.hash(this.password, 10);
   }
+
+  @OneToMany(() => Testimonial, testimonial => testimonial.user)
+  testimonials: Testimonial[];
+
+  @OneToMany(() => Notification, notification => notification.user)
+  notifications: Notification[];
 }


### PR DESCRIPTION
## What does the PR do?

This feature allows users to mark a specific notification as read. The endpoint takes a notification ID as a parameter and updates the is_read status of the notification.

How should this be manually tested?

1. Login to a user account, and get the access token

2. Make a PATCH request to the `\api\v1\notifications\{notification_id}` endpoint with the following payload:

```json
Authorization: Bearer <access_token>

{
   " is_read": true
}
```

Successful Response
On a successful notification update, the API should return a 200 status code.

```json
{
      "status": "success",
     "status_code": 200,
     "data": {
         "notification_id": "uuid",
         "is_read": true,
        "updated_at": "2024-07-28T12:00:00Z"
      }
}
```

Authentication Error:
When the current user is not properly authenticated to change the organization detail:

```json
{
  "status": "error",
  "message": "Unauthorized request",
  "status_code": 401
}
```

Invalid UserID Error
On Invalid error, if the user is not found with the provided id:
```json
{
  "status": "error",
  "message": "Notification not found",
  "status_code": 404
}
```

Validation:
If any required field is missing or invalid, the response should return a 400 Bad Request status code with appropriate validation error messages.

```json
{
  "status": "error",
  "message": ["notification_id must be a string"],
  "status_code": "400"
}
```
Task

- [x] Implemented PATCH /api/v1/notifications/{notification_id} endpoint in notifications.controller.ts.
- [x] Added method to update the read status of a notification in the NotificationsService.
- [x] Tested endpoint functionality to ensure it handles various scenarios correctly.
- [x] Added appropriate HTTP status codes and response messages for edge cases.
- [x] Added unit tests for the NotificationsService.
- [x] Updated API documentation to reflect the new endpoint.

Reference Issue: [Link to Issue](https://linear.app/team-bingo/issue/BAC2-139/clearing-a-single-or-multiple-notification)