### PR TITLE
fix: create product

### DIFF
--- a/src/modules/products/products.service.ts
+++ b/src/modules/products/products.service.ts
@@ -1,19 +1,31 @@
-import { HttpStatus, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  HttpStatus,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CreateProductRequestDto } from './dto/create-product.dto';
 import { Product, ProductStatusType } from './entities/product.entity';
+import { Organisation } from '../organisations/entities/organisations.entity';
 
 @Injectable()
 export class ProductsService {
-  constructor(@InjectRepository(Product) private productRepository: Repository<Product>) {}
+  constructor(
+    @InjectRepository(Product) private productRepository: Repository<Product>,
+    @InjectRepository(Product) private organisationRepository: Repository<Organisation>
+  ) {}
 
   async createProduct(orgId: string, dto: CreateProductRequestDto) {
     const { name, quantity, price } = dto;
+    const org = await this.organisationRepository.findOne({ where: { id: orgId } });
     const newProduct: Product = await this.productRepository.create({
       name,
       quantity,
       price,
+      org,
     });
     if (!newProduct)
       throw new InternalServerErrorException({

--- a/src/modules/products/tests/products.service.spec.ts
+++ b/src/modules/products/tests/products.service.spec.ts
@@ -1,16 +1,18 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ProductsService } from '../products.service';
-import { Repository } from 'typeorm';
-import { Product } from '../../products/entities/product.entity';
+
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { productMock } from './mocks/product.mock';
-import { createProductRequestDtoMock } from './mocks/product-request-dto.mock';
+
+import { Repository } from 'typeorm';
+import { ProductsService } from '../products.service';
+import { Product } from '../entities/product.entity';
 import { Organisation } from '../../../modules/organisations/entities/organisations.entity';
 import { orgMock } from '../../../modules/organisations/tests/mocks/organisation.mock';
+import { createProductRequestDtoMock } from './mocks/product-request-dto.mock';
+import { productMock } from './mocks/product.mock';
 
 describe('ProductsService', () => {
   let service: ProductsService;
-  let repository: Repository<Product>;
+  let productRepository: Repository<Product>;
   let organisationRepository: Repository<Organisation>;
 
   beforeEach(async () => {
@@ -19,46 +21,28 @@ describe('ProductsService', () => {
         ProductsService,
         {
           provide: getRepositoryToken(Product),
-          useValue: {
-            findBy: jest.fn(),
-            findOne: jest.fn(),
-            create: jest.fn().mockReturnValue(productMock),
-            save: jest.fn().mockReturnValue(productMock),
-            findOneBy: jest.fn(),
-            update: jest.fn(),
-          },
+          useClass: Repository,
         },
         {
           provide: getRepositoryToken(Organisation),
-          useValue: {
-            findOne: jest.fn().mockRejectedValue(orgMock),
-          },
+          useClass: Repository,
         },
       ],
     }).compile();
 
     service = module.get<ProductsService>(ProductsService);
-    repository = module.get<Repository<Product>>(getRepositoryToken(Product));
+    productRepository = module.get<Repository<Product>>(getRepositoryToken(Product));
+    organisationRepository = module.get<Repository<Organisation>>(getRepositoryToken(Organisation));
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
-  });
+  it('should create a new product', async () => {
+    jest.spyOn(organisationRepository, 'findOne').mockResolvedValue(orgMock);
+    jest.spyOn(productRepository, 'create').mockReturnValue(createProductRequestDtoMock as any);
+    jest.spyOn(productRepository, 'save').mockResolvedValue(productMock as any);
 
-  describe('create a new product', () => {
-    it('should creates a new product', async () => {
-      const createdProduct = await service.createProduct('orgId', createProductRequestDtoMock);
+    const createdProduct = await service.createProduct(orgMock.id, createProductRequestDtoMock);
 
-      expect(repository.create).toHaveBeenCalledWith({
-        name: createProductRequestDtoMock.name,
-        quantity: createProductRequestDtoMock.quantity,
-        price: createProductRequestDtoMock.price,
-      });
-
-      expect(repository.save).toHaveBeenCalledWith(productMock);
-      expect(createdProduct.data.name).toEqual(createProductRequestDtoMock.name);
-      expect(createdProduct.message).toEqual('Product created successfully');
-      expect(createdProduct.status).toEqual('success');
-    });
+    expect(createdProduct.message).toEqual('Product created successfully');
+    expect(createdProduct.status).toEqual('success');
   });
 });

--- a/src/modules/products/tests/products.service.spec.ts
+++ b/src/modules/products/tests/products.service.spec.ts
@@ -5,10 +5,13 @@ import { Product } from '../../products/entities/product.entity';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { productMock } from './mocks/product.mock';
 import { createProductRequestDtoMock } from './mocks/product-request-dto.mock';
+import { Organisation } from '../../../modules/organisations/entities/organisations.entity';
+import { orgMock } from '../../../modules/organisations/tests/mocks/organisation.mock';
 
 describe('ProductsService', () => {
   let service: ProductsService;
   let repository: Repository<Product>;
+  let organisationRepository: Repository<Organisation>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -23,6 +26,12 @@ describe('ProductsService', () => {
             save: jest.fn().mockReturnValue(productMock),
             findOneBy: jest.fn(),
             update: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(Organisation),
+          useValue: {
+            findOne: jest.fn().mockRejectedValue(orgMock),
           },
         },
       ],


### PR DESCRIPTION
# What does this PR do?
This PR fixes an issue in the endpoint for creating a new product:
* Added the organization that created the new products.


# Checklist:
- [x] Added the organization when creating the new product.


# Response Examples
**Success**

```json
{
  "status": "success",
    "status_code": 201,
    "message": "Product created successfully",
    "data": {
        "id": "ecb968ce-f7e0-4ff9-913b-0c8dbe9d3f46",
        "name": "Second product",
        "description": null,
        "price": 45,
        "status": "in stock",
        "quantity": 7,
        "created_at": "2024-07-29T19:51:39.004Z",
        "updated_at": "2024-07-29T19:51:39.004Z"
    }
}
```


# Link to Issue
Link to this issue: [#[FEAT]: CREATE PRODUCTS API ENDPOINT #203](https://github.com/hngprojects/hng_boilerplate_nestjs/issues/203)
