### PR TITLE
feat: run python script on server and display in browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@nestjs-modules/mailer": "^2.0.2",
         "@nestjs/cli": "^10.0.0",
         "@nestjs/common": "^10.3.10",
-        "@nestjs/schematics": "^10.0.0",
+        "@nestjs/schematics": "^10.1.3",
         "@nestjs/testing": "^10.3.10",
         "@types/bcrypt": "^5.0.2",
         "@types/express": "^4.17.17",
@@ -70,7 +70,7 @@
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "^5.5.3"
+        "typescript": "^5.5.4"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,33 +1,34 @@
 import { MailerModule } from '@nestjs-modules/mailer';
+import { HandlebarsAdapter } from '@nestjs-modules/mailer/dist/adapters/handlebars.adapter';
 import { Module, ValidationPipe } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { APP_PIPE } from '@nestjs/core';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import * as Joi from 'joi';
 import { LoggerModule } from 'nestjs-pino';
+import authConfig from '../config/auth.config';
 import serverConfig from '../config/server.config';
 import dataSource from './database/data-source';
 import { SeedingModule } from './database/seeding/seeding.module';
+import { AuthGuard } from './guards/auth.guard';
 import HealthController from './health.controller';
-import ProbeController from './probe.controller';
 import { AuthModule } from './modules/auth/auth.module';
-import { UserModule } from './modules/user/user.module';
+import { EmailModule } from './modules/email/email.module';
+import { EmailService } from './modules/email/email.service';
+import { InviteModule } from './modules/invite/invite.module';
+import { JobsModule } from './modules/jobs/jobs.module';
+import { OrganisationsModule } from './modules/organisations/organisations.module';
 import { OtpModule } from './modules/otp/otp.module';
 import { OtpService } from './modules/otp/otp.service';
-import { TimezonesModule } from './modules/timezones/timezones.module';
-import authConfig from '../config/auth.config';
-import { OrganisationsModule } from './modules/organisations/organisations.module';
-import { AuthGuard } from './guards/auth.guard';
-import { HandlebarsAdapter } from '@nestjs-modules/mailer/dist/adapters/handlebars.adapter';
-import { SqueezeModule } from './modules/squeeze/squeeze.module';
-import { EmailService } from './modules/email/email.service';
-import { EmailModule } from './modules/email/email.module';
-import { InviteModule } from './modules/invite/invite.module';
-import { TestimonialsModule } from './modules/testimonials/testimonials.module';
-import { NotificationSettingsModule } from './modules/settings/notification-settings/notification-settings.module';
 import { ProductsModule } from './modules/products/products.module';
-import { JobsModule } from './modules/jobs/jobs.module';
 import { ProfileModule } from './modules/profile/profile.module';
+import { NotificationSettingsModule } from './modules/settings/notification-settings/notification-settings.module';
+import { SqueezeModule } from './modules/squeeze/squeeze.module';
+import { TestimonialsModule } from './modules/testimonials/testimonials.module';
+import { TimezonesModule } from './modules/timezones/timezones.module';
+import { UserModule } from './modules/user/user.module';
+import ProbeController from './probe.controller';
+import { RunTestsModule } from './run-tests/run-tests.module';
 
 @Module({
   providers: [
@@ -117,6 +118,7 @@ import { ProfileModule } from './modules/profile/profile.module';
     ProductsModule,
     JobsModule,
     ProfileModule,
+    RunTestsModule,
   ],
   controllers: [HealthController, ProbeController],
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,7 @@ async function bootstrap() {
   app.enable('trust proxy');
   app.useLogger(logger);
   app.enableCors();
-  app.setGlobalPrefix('api/v1', { exclude: ['/', 'health', 'api', 'api/v1', 'api/docs', 'probe'] });
+  app.setGlobalPrefix('api/v1', { exclude: ['/', 'run-tests', 'health', 'api', 'api/v1', 'api/docs', 'probe'] });
   app.useGlobalInterceptors(new ResponseInterceptor());
 
   // TODO: set options for swagger docs

--- a/src/run-tests/python.py
+++ b/src/run-tests/python.py
@@ -1,0 +1,16 @@
+import time
+
+def main():
+    print("Starting the test script...")
+    time.sleep(1)  # Simulate some delay
+    print("Running tests...")
+    time.sleep(2)  # Simulate running tests
+    print("Test 1: Success")
+    time.sleep(1)
+    print("Test 2: Failed")
+    time.sleep(1)
+    print("All tests completed.")
+    print("Exiting script...")
+
+if __name__ == "__main__":
+    main()

--- a/src/run-tests/run-tests.controller.ts
+++ b/src/run-tests/run-tests.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Res } from '@nestjs/common';
+import { Response } from 'express';
+import { skipAuth } from '../helpers/skipAuth';
+import { RunTestsService } from './run-tests.service';
+
+@Controller('/run-tests')
+export class RunTestsController {
+  constructor(private readonly runTestsService: RunTestsService) {}
+  @skipAuth()
+  @Get()
+  runTests(@Res() res: Response) {
+    return this.runTestsService.runTests(res);
+  }
+}

--- a/src/run-tests/run-tests.module.ts
+++ b/src/run-tests/run-tests.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { RunTestsService } from './run-tests.service';
+import { RunTestsController } from './run-tests.controller';
+
+@Module({
+  controllers: [RunTestsController],
+  providers: [RunTestsService],
+})
+export class RunTestsModule {}

--- a/src/run-tests/run-tests.service.spec.ts
+++ b/src/run-tests/run-tests.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RunTestsService } from './run-tests.service';
+
+describe('RunTestsService', () => {
+  let service: RunTestsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RunTestsService],
+    }).compile();
+
+    service = module.get<RunTestsService>(RunTestsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/run-tests/run-tests.service.ts
+++ b/src/run-tests/run-tests.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { spawn } from 'child_process';
+import { Response } from 'express';
+
+@Injectable()
+export class RunTestsService {
+  runTests(res: Response) {
+    const process = spawn('python', ['src/tests/python.py']);
+
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+
+    process.stdout.on('data', data => {
+      res.write(`data: ${data.toString()}\n\n`);
+    });
+
+    process.stderr.on('data', data => {
+      res.write(`data: Error: ${data.toString()}\n\n`);
+    });
+
+    process.on('close', data => {
+      res.write(`data scriot exited with code ${data}\n\n`);
+      res.end();
+    });
+
+    process.on('error', err => {
+      res.write(`data: Error: ${err.message}\n\n`);
+      res.end;
+    });
+  }
+}


### PR DESCRIPTION
## What does this PR do?

This PR implements an API endpoint in the NestJS application to run compatibility tests using a Python script. The script simulates testing various API endpoints and streams the output to the user on the browser.

## How should this be manually tested?

1. **Start the NestJS server:**
   Ensure your NestJS server is running.

2. **Open the path on the browser**
   
Navigate to `BASE_URL/run-tests` in the browser.

3. **Observe the response:**
   The server should stream the output from the Python script in real-time. The response should look like this:

   ```
   Starting the test script...
   Running tests...
   Test 1: Success
   Test 2: Failed
   All tests completed.
   Exiting script...
   ```


## Requirements
- [x] Make sure python is installed.

## Checklist

- [x] Define API endpoint `GET /run-tests` in the NestJS service.
- [x] Implement a service method to run the Python script and stream the output.
- [x] Use Python's subprocess to execute the script and capture the output in real-time.
- [x] Handle error cases if the script fails to execute.

## Additional Notes

- Ensure the Python script (`python.py`) is executable and available in the project directory.
- The Python script used for testing is a placeholder and can be replaced with actual test scripts as needed.

## Reference Issue

Mark wants it