### PR TITLE
feat: Get all members in an organization

### DIFF
--- a/src/modules/organisations/dto/org-members-response.dto.ts
+++ b/src/modules/organisations/dto/org-members-response.dto.ts
@@ -1,0 +1,7 @@
+import UserInterface from '../../user/interfaces/UserInterface';
+
+export class OrganisationMembersResponseDto {
+  status_code: number;
+  data: Omit<Partial<UserInterface>, 'password'>[];
+  message: string;
+}

--- a/src/modules/organisations/mapper/org-members.mapper.ts
+++ b/src/modules/organisations/mapper/org-members.mapper.ts
@@ -1,0 +1,16 @@
+import { User } from '../../user/entities/user.entity';
+
+export class OrganisationMemberMapper {
+  static mapToResponseFormat(member: User) {
+    if (!member) {
+      throw new Error('User entity is required');
+    }
+
+    return {
+      id: member.id,
+      name: `${member.first_name} ${member.last_name}`,
+      phone_number: member.phone,
+      email: member.email,
+    };
+  }
+}

--- a/src/modules/organisations/organisations.controller.ts
+++ b/src/modules/organisations/organisations.controller.ts
@@ -9,6 +9,7 @@ import {
   Patch,
   Post,
   Query,
+  Req,
   Request,
   Res,
   UseGuards,
@@ -64,10 +65,12 @@ export class OrganisationsController {
   })
   @Get(':org_id/users')
   async getMembers(
+    @Req() req,
     @Param('org_id') org_id: string,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
     @Query('page_size', new DefaultValuePipe(1), ParseIntPipe) page_size: number
   ): Promise<OrganisationMembersResponseDto> {
-    return this.organisationsService.getOrganisationMembers(org_id, page, page_size);
+    const { sub } = req.user;
+    return this.organisationsService.getOrganisationMembers(org_id, page, page_size, sub);
   }
 }

--- a/src/modules/organisations/organisations.controller.ts
+++ b/src/modules/organisations/organisations.controller.ts
@@ -60,8 +60,11 @@ export class OrganisationsController {
   })
   @ApiResponse({
     status: 404,
-    description: 'Organisation not found or no user in it',
-    type: UpdateOrganisationDto,
+    description: 'Organisation not found',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'User not a member of the organisation',
   })
   @Get(':org_id/users')
   async getMembers(

--- a/src/modules/organisations/organisations.controller.ts
+++ b/src/modules/organisations/organisations.controller.ts
@@ -1,9 +1,10 @@
-import { Body, Controller, Delete, Param, Patch, Post, Request, Res, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Request, Res, UseGuards } from '@nestjs/common';
 import { OrganisationsService } from './organisations.service';
 import { OrganisationRequestDto } from './dto/organisation.dto';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { UpdateOrganisationDto } from './dto/update-organisation.dto';
 import { OwnershipGuard } from '../../guards/authorization.guard';
+import { OrganisationMembersResponseDto } from './dto/org-members-response.dto';
 
 @ApiBearerAuth()
 @ApiTags('Organisation')
@@ -34,5 +35,21 @@ export class OrganisationsController {
   async update(@Param('id') id: string, @Body() updateOrganisationDto: UpdateOrganisationDto) {
     const updatedOrg = await this.organisationsService.updateOrganisation(id, updateOrganisationDto);
     return { message: 'Organisation successfully updated', org: updatedOrg };
+  }
+
+  @ApiOperation({ summary: 'Get members of an Organisation' })
+  @ApiResponse({
+    status: 200,
+    description: 'The found record',
+    type: OrganisationMembersResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Organisation not found or no user in it',
+    type: UpdateOrganisationDto,
+  })
+  @Get(':org_id/users')
+  async getMembers(@Param('org_id') org_id: string): Promise<OrganisationMembersResponseDto> {
+    return this.organisationsService.getOrganisationMembers(org_id);
   }
 }

--- a/src/modules/organisations/organisations.controller.ts
+++ b/src/modules/organisations/organisations.controller.ts
@@ -1,4 +1,18 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, Request, Res, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  DefaultValuePipe,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  Request,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { OrganisationsService } from './organisations.service';
 import { OrganisationRequestDto } from './dto/organisation.dto';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
@@ -49,7 +63,11 @@ export class OrganisationsController {
     type: UpdateOrganisationDto,
   })
   @Get(':org_id/users')
-  async getMembers(@Param('org_id') org_id: string): Promise<OrganisationMembersResponseDto> {
-    return this.organisationsService.getOrganisationMembers(org_id);
+  async getMembers(
+    @Param('org_id') org_id: string,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('page_size', new DefaultValuePipe(1), ParseIntPipe) page_size: number
+  ): Promise<OrganisationMembersResponseDto> {
+    return this.organisationsService.getOrganisationMembers(org_id, page, page_size);
   }
 }

--- a/src/modules/organisations/organisations.service.ts
+++ b/src/modules/organisations/organisations.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ForbiddenException,
   HttpCode,
   HttpStatus,
   Injectable,
@@ -40,23 +41,14 @@ export class OrganisationsService {
       relations: ['organisationMembers', 'organisationMembers.user_id'],
     });
 
-    if (!orgs)
-      throw new NotFoundException({
-        message: 'No organisation found',
-        status_code: HttpStatus.NOT_FOUND,
-      });
+    if (!orgs) throw new NotFoundException('No organisation found');
 
     let data = orgs.organisationMembers.map(member => {
       return OrganisationMemberMapper.mapToResponseFormat(member.user_id);
     });
 
     const isMember = data.find(member => member.id === sub);
-
-    if (!isMember)
-      throw new UnauthorizedException({
-        message: 'User does not have access to the organization',
-        status_code: HttpStatus.FORBIDDEN,
-      });
+    if (!isMember) throw new ForbiddenException('User does not have access to the organization');
 
     data = data.splice(skip, skip + page_size);
 

--- a/src/modules/organisations/tests/organisations.service.spec.ts
+++ b/src/modules/organisations/tests/organisations.service.spec.ts
@@ -13,6 +13,7 @@ import {
   InternalServerErrorException,
   NotFoundException,
   UnprocessableEntityException,
+  ForbiddenException,
 } from '@nestjs/common';
 
 describe('OrganisationsService', () => {
@@ -158,6 +159,81 @@ describe('OrganisationsService', () => {
       jest.spyOn(organisationRepository, 'findOneBy').mockRejectedValueOnce(new Error('Unexpected error'));
 
       await expect(service.updateOrganisation(id, updateOrganisationDto)).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+
+  describe('getOrganisationMembers', () => {
+    it('should throw NotFoundException if organisation is not found', async () => {
+      organisationRepository.findOne = jest.fn().mockResolvedValue(null);
+
+      await expect(service.getOrganisationMembers('orgId', 1, 2, 'testUserId')).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ForbiddenException if the user is not a member', async () => {
+      const mockOrganisation = {
+        id: 'orgId',
+        organisationMembers: [
+          {
+            user_id: { id: 'anotherUserId' },
+          },
+        ],
+      } as unknown as Organisation;
+
+      organisationRepository.findOne = jest.fn().mockResolvedValue(mockOrganisation);
+
+      await expect(service.getOrganisationMembers('orgId', 1, 10, 'sub')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should return paginated members if the user is a member', async () => {
+      const mockOrganisation = {
+        id: 'orgId',
+        organisationMembers: [
+          { user_id: { id: 'sub', first_name: 'John', last_name: 'Doe', email: 'john@email.com', phone: '0000' } },
+          {
+            user_id: {
+              id: 'anotherUserId',
+              first_name: 'Jane',
+              last_name: 'Doe',
+              email: 'jane@email.com',
+              phone: '1111',
+            },
+          },
+        ],
+      } as unknown as Organisation;
+
+      organisationRepository.findOne = jest.fn().mockResolvedValue(mockOrganisation);
+
+      const result = await service.getOrganisationMembers('orgId', 1, 1, 'sub');
+
+      expect(result.status_code).toBe(200);
+      expect(result.data).toEqual([{ id: 'sub', name: 'John Doe', email: 'john@email.com', phone_number: '0000' }]);
+    });
+
+    it('should paginate members correctly', async () => {
+      const mockOrganisation = {
+        id: 'orgId',
+        organisationMembers: [
+          { user_id: { id: 'sub', first_name: 'John', last_name: 'Doe', email: 'john@email.com', phone: '0000' } },
+          {
+            user_id: {
+              id: 'anotherUserId',
+              first_name: 'Jane',
+              last_name: 'Doe',
+              email: 'jane@email.com',
+              phone: '1111',
+            },
+          },
+        ],
+      } as unknown as Organisation;
+
+      organisationRepository.findOne = jest.fn().mockResolvedValue(mockOrganisation);
+
+      const result = await service.getOrganisationMembers('orgId', 2, 1, 'sub');
+
+      expect(result.status_code).toBe(200);
+      expect(result.data).toEqual([
+        { id: 'anotherUserId', name: 'Jane Doe', email: 'jane@email.com', phone_number: '1111' },
+      ]);
     });
   });
 });


### PR DESCRIPTION
# What does this PR do
Implements backend functionality for retrieving users belonging to a particular organisation, accessible only to a member of that organisation.

[Link to GitHub Issue #79](https://github.com/hngprojects/hng_boilerplate_nestjs/issues/79)

## Acceptance Criteria

- The endpoint should be accessible at `api/v1/organization/:org_id/users`

- The endpoint should accept HTTP GET requests.

- The endpoint should be secured to ensure that only authenticated users can fetch users in the organization

- The endpoint should check that the user is a member of the organization

- The endpoint should check that the organisation Id in the url path is an existing organization

- Requests to the endpoint must include a valid authentication token in the Authorization header. Authorization: Bearer <token>

## Request

GET `/api/v1/organization/:org_id/users`

## Parameters:

orgId - `string` - The id of the organisation whose users are to be retrieved

## Query Parameters:

`page`: integer (optional) defaults to 1 - Pagination parameter specifying the page number to be retrieved

`page_size`: integer (optional) defaults to 1 - Pagination parameter specifying the number of users retrieved per page

## Expected Outcome

### Successful Response

- On success, the list of users in the organisation should be sent with a 200 status code

- The response body should contain a list of users, including the userId.
```
{
   "status": "success",
   "message": "Users retrieved successfully",
   "data": [
     {
       "id": "String",
       "email": "String",
       "phone_number": "String",
       "name": "String"
     },
   ],
   "status_code": 200
}
```
### Server Error Response

- Status: 500 Internal Server Error

- Body:
```
{
  "error": "Internal server error"
  "status_code": 500
}

```
### Unauthenticated User Error

- Status: 401 Unauthorized

- Description: This error is returned when a user tries to access this endpoint while not logged in

- Body:
```
{
  "error": "User not logged in"
  "status_code": 401
}
```
### Forbidden User Error

- Status: 403 Forbidden

- Description: This error is returned when a user tries to retrieve the list of users of an organization they are not a part of

- Body:
```
{
  "error": "User does not have access to the organization"
  "status_code": 403
}
```
## Purpose

- Provides a backend service which allows users to fetch all users in their organization

## Requirements

- Develop server-side logic to fetch all users of a single organisation

- Ensure compliance with security standards for handling user information.

## Unit tests:

- Successful users retrieval with a valid token and User ID.

- Test for unauthorized access without a valid token.

- Test for forbidden access when the user lacks appropriate permissions.

- Perform security testing to ensure data protection and compliance.