### PR TITLE
feat: delete job listing endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
       "devDependencies": {
         "@commitlint/cli": "^19.3.0",
         "@commitlint/config-conventional": "^19.2.2",
+        "@golevelup/ts-jest": "^0.5.0",
         "@nestjs-modules/mailer": "^2.0.2",
         "@nestjs/cli": "^10.0.0",
         "@nestjs/common": "^10.3.10",
@@ -1256,6 +1257,12 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
         "npm": ">=6.14.13"
       }
+    },
+    "node_modules/@golevelup/ts-jest": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@golevelup/ts-jest/-/ts-jest-0.5.0.tgz",
+      "integrity": "sha512-UniUNOBraDD8vf6QNUPkpWMzhUXBtw40nCHekgBlaHy2p99MDV0aYLp4ZXifiyPOsFmg4BZQGs60lF6EpV7JpA==",
+      "dev": true
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^19.2.2",
+    "@golevelup/ts-jest": "^0.5.0",
     "@nestjs-modules/mailer": "^2.0.2",
     "@nestjs/cli": "^10.0.0",
     "@nestjs/common": "^10.3.10",

--- a/src/guards/authorization.guard.ts
+++ b/src/guards/authorization.guard.ts
@@ -4,7 +4,6 @@ import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserType } from '../modules/user/entities/user.entity';
 import { Organisation } from './../modules/organisations/entities/organisations.entity';
-import { Job } from '../modules/jobs/entities/job.entity';
 
 @Injectable()
 export class OwnershipGuard implements CanActivate {

--- a/src/modules/jobs/guards/job.guard.ts
+++ b/src/modules/jobs/guards/job.guard.ts
@@ -19,7 +19,7 @@ export class JobGuard implements CanActivate {
       relations: ['user'],
     });
 
-    if (job.user.id === user.sub) {
+    if (job.user.id === user.id) {
       if (!job || job.is_deleted === true) throw new NotFoundException('Job not found');
       return true;
     } else {

--- a/src/modules/jobs/jobs.controller.ts
+++ b/src/modules/jobs/jobs.controller.ts
@@ -41,6 +41,9 @@ export class JobsController {
 
   @UseGuards(JobGuard)
   @Delete('/:id')
+  @ApiResponse({ status: 200, description: 'Job deleted successfully' })
+  @ApiResponse({ status: 403, description: 'You do not have permission to perform this action' })
+  @ApiResponse({ status: 404, description: 'Job not found' })
   async delete(@Param('id') id: string) {
     return this.jobService.delete(id);
   }

--- a/src/modules/jobs/jobs.controller.ts
+++ b/src/modules/jobs/jobs.controller.ts
@@ -41,6 +41,7 @@ export class JobsController {
 
   @UseGuards(JobGuard)
   @Delete('/:id')
+  @ApiOperation({ summary: 'Delete a job' })
   @ApiResponse({ status: 200, description: 'Job deleted successfully' })
   @ApiResponse({ status: 403, description: 'You do not have permission to perform this action' })
   @ApiResponse({ status: 404, description: 'Job not found' })

--- a/src/modules/jobs/jobs.controller.ts
+++ b/src/modules/jobs/jobs.controller.ts
@@ -3,8 +3,8 @@ import { JobsService } from './jobs.service';
 import { JobDto } from './dto/job.dto';
 import { PaginationDto } from './dto/pagination.dto';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { skipAuth } from '../../helpers/skipAuth';
 import { JobGuard } from './guards/job.guard';
+import { skipAuth } from '../../helpers/skipAuth';
 
 @ApiTags('Jobs')
 @ApiBearerAuth()

--- a/src/modules/jobs/jobs.controller.ts
+++ b/src/modules/jobs/jobs.controller.ts
@@ -4,6 +4,7 @@ import { JobDto } from './dto/job.dto';
 import { PaginationDto } from './dto/pagination.dto';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { skipAuth } from '../../helpers/skipAuth';
+import { JobGuard } from './guards/job.guard';
 
 @ApiTags('Jobs')
 @ApiBearerAuth()
@@ -36,5 +37,11 @@ export class JobsController {
   @ApiResponse({ status: 404, description: 'Job not found' })
   async getJob(@Param('id') id: string) {
     return this.jobService.getJob(id);
+  }
+
+  @UseGuards(JobGuard)
+  @Delete('/:id')
+  async delete(@Param('id') id: string) {
+    return this.jobService.delete(id);
   }
 }

--- a/src/modules/jobs/jobs.service.ts
+++ b/src/modules/jobs/jobs.service.ts
@@ -69,4 +69,23 @@ export class JobsService {
       data: job,
     };
   }
+  async delete(jobId: string) {
+    // Check if listing exists
+    const job = await this.jobRepository.findOne({
+      where: { id: jobId },
+    });
+
+    job.is_deleted = true;
+    const deleteJobEntityInstance = this.jobRepository.create(job);
+
+    // Save the new Job entity to the database
+    await this.jobRepository.save(deleteJobEntityInstance);
+
+    // Return a success response
+    return {
+      status: 'success',
+      message: 'Job details deleted successfully',
+      status_code: 200,
+    };
+  }
 }

--- a/src/modules/jobs/tests/job.guard.spec.ts
+++ b/src/modules/jobs/tests/job.guard.spec.ts
@@ -1,0 +1,86 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { JobGuard } from '../../../guards/authorization.guard'; // Adjust the import path as necessary
+import { Repository } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Job } from '../entities/job.entity';
+import { createMock } from '@golevelup/ts-jest';
+
+describe('JobGuard', () => {
+  let guard: JobGuard;
+  let jobRepository: Repository<Job>;
+
+  const mockJobRepository = {
+    findOne: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        {
+          provide: getRepositoryToken(Job),
+          useValue: mockJobRepository,
+        },
+      ],
+    }).compile();
+
+    jobRepository = module.get<Repository<Job>>(getRepositoryToken(Job));
+    guard = new JobGuard(jobRepository);
+  });
+
+  it('should allow access if the job belongs to the user', async () => {
+    const mockJob = { id: '1', user: { id: 'user123' }, is_deleted: false } as Job;
+    mockJobRepository.findOne.mockResolvedValue(mockJob);
+    const mockContext = createMock<ExecutionContext>();
+
+    mockContext.switchToHttp().getRequest.mockReturnValue({
+      user: { sub: 'user123' },
+      params: { id: 1 },
+    });
+    const result = await guard.canActivate(mockContext);
+
+    expect(result).toBe(true);
+  });
+
+  it('should throw NotFoundException if the job is deleted', async () => {
+    const mockJob = { id: '1', user: { id: 'user123' }, is_deleted: true } as Job;
+    mockJobRepository.findOne.mockResolvedValue(mockJob);
+
+    const mockContext = createMock<ExecutionContext>();
+
+    mockContext.switchToHttp().getRequest.mockReturnValue({
+      user: { sub: 'user123' },
+      params: { id: 1 },
+    });
+
+    await expect(guard.canActivate(mockContext)).rejects.toThrow(NotFoundException);
+  });
+
+  it('should throw ForbiddenException if the job does not belong to the user', async () => {
+    const mockJob = { id: '1', user: { id: 'user456' }, is_deleted: false } as Job;
+    mockJobRepository.findOne.mockResolvedValue(mockJob);
+
+    const mockContext = createMock<ExecutionContext>();
+
+    mockContext.switchToHttp().getRequest.mockReturnValue({
+      user: { sub: 'user123' },
+      params: { id: 1 },
+    });
+
+    await expect(guard.canActivate(mockContext)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('should throw NotFoundException if the job is not found', async () => {
+    const mockJob = { id: '1', user: { id: 'user456' }, is_deleted: true } as Job;
+    mockJobRepository.findOne.mockResolvedValue(mockJob);
+
+    const mockContext = createMock<ExecutionContext>();
+
+    mockContext.switchToHttp().getRequest.mockReturnValue({
+      user: { sub: 'user456' },
+      params: { id: 1 },
+    });
+
+    await expect(guard.canActivate(mockContext)).rejects.toThrow(NotFoundException);
+  });
+});

--- a/src/modules/jobs/tests/job.guard.spec.ts
+++ b/src/modules/jobs/tests/job.guard.spec.ts
@@ -34,7 +34,7 @@ describe('JobGuard', () => {
     const mockContext = createMock<ExecutionContext>();
 
     mockContext.switchToHttp().getRequest.mockReturnValue({
-      user: { sub: 'user123' },
+      user: { id: 'user123' },
       params: { id: 1 },
     });
     const result = await guard.canActivate(mockContext);
@@ -49,7 +49,7 @@ describe('JobGuard', () => {
     const mockContext = createMock<ExecutionContext>();
 
     mockContext.switchToHttp().getRequest.mockReturnValue({
-      user: { sub: 'user123' },
+      user: { id: 'user123' },
       params: { id: 1 },
     });
 
@@ -63,7 +63,7 @@ describe('JobGuard', () => {
     const mockContext = createMock<ExecutionContext>();
 
     mockContext.switchToHttp().getRequest.mockReturnValue({
-      user: { sub: 'user123' },
+      user: { id: 'user123' },
       params: { id: 1 },
     });
 
@@ -77,7 +77,7 @@ describe('JobGuard', () => {
     const mockContext = createMock<ExecutionContext>();
 
     mockContext.switchToHttp().getRequest.mockReturnValue({
-      user: { sub: 'user456' },
+      user: { id: 'user456' },
       params: { id: 1 },
     });
 

--- a/src/modules/jobs/tests/job.guard.spec.ts
+++ b/src/modules/jobs/tests/job.guard.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ExecutionContext, ForbiddenException, NotFoundException } from '@nestjs/common';
-import { JobGuard } from '../../../guards/authorization.guard'; // Adjust the import path as necessary
+import { JobGuard } from '../guards/job.guard';
 import { Repository } from 'typeorm';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Job } from '../entities/job.entity';

--- a/src/modules/jobs/tests/jobs.service.spec.ts
+++ b/src/modules/jobs/tests/jobs.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { JobsService } from '../jobs.service';
 import { JobDto } from '../dto/job.dto';
-import { Repository } from 'typeorm';
+import { DeleteResult, Repository } from 'typeorm';
 import { Job } from '../entities/job.entity';
 import UserResponseDTO from '../../user/dto/user-response.dto';
 import { User } from '../../user/entities/user.entity';
@@ -12,8 +12,27 @@ describe('JobsService', () => {
   let service: JobsService;
   let jobRepository: Repository<Job>;
   let userRepository: Repository<User>;
+  let userDto: UserResponseDTO;
+  let createJobDto: JobDto;
 
   beforeEach(async () => {
+    userDto = {
+      id: 'user_id',
+      email: 'test@example.com',
+    };
+
+    createJobDto = {
+      title: 'Software Engineer II',
+      description:
+        'We are looking for a skilled Software Engineer to join our team. The ideal candidate will have experience in building high-performance applications.',
+      location: 'New York, NY',
+      deadline: '2024-12-31T23:59:59Z',
+      salary_range: '70k_to_100k',
+      job_type: 'full-time',
+      job_mode: 'remote',
+      company_name: 'Tech Innovators Inc.',
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         JobsService,
@@ -46,6 +65,13 @@ describe('JobsService', () => {
     service = module.get<JobsService>(JobsService);
     userRepository = module.get(getRepositoryToken(User));
     jobRepository = module.get(getRepositoryToken(Job));
+
+    jest.spyOn(userRepository, 'findOne').mockResolvedValue(userDto as User);
+    jest.spyOn(jobRepository, 'create').mockReturnValue({ ...createJobDto, user: userDto } as Job);
+    jest
+      .spyOn(jobRepository, 'findOne')
+      .mockResolvedValue({ ...createJobDto, is_deleted: false, user: userDto } as Job);
+    jest.spyOn(jobRepository, 'save').mockResolvedValue({ ...createJobDto } as Job);
   });
 
   it('should be defined', () => {
@@ -53,26 +79,7 @@ describe('JobsService', () => {
   });
 
   describe('createNewJob', () => {
-    const userDto: UserResponseDTO = {
-      id: 'user_id',
-      email: 'test@example.com',
-    };
-    const createJobDto: JobDto = {
-      title: 'Software Engineer II',
-      description:
-        'We are looking for a skilled Software Engineer to join our team. The ideal candidate will have experience in building high-performance applications.',
-      location: 'New York, NY',
-      deadline: '2024-12-31T23:59:59Z',
-      salary_range: '70k_to_100k',
-      job_type: 'full-time',
-      job_mode: 'remote',
-      company_name: 'Tech Innovators Inc.',
-    };
-
     it('should create a new job successfully', async () => {
-      jest.spyOn(userRepository, 'findOne').mockResolvedValue(userDto as User);
-      jest.spyOn(jobRepository, 'create').mockReturnValue({ ...createJobDto, user: userDto } as Job);
-      jest.spyOn(jobRepository, 'save').mockResolvedValue({ ...createJobDto } as Job);
       const result = await service.create(createJobDto, userDto.id);
       expect(result.status).toEqual('success');
       expect(result.message).toEqual('Job listing created successfully');
@@ -86,6 +93,14 @@ describe('JobsService', () => {
       const jobs = await service.getJobs();
       expect(jobs.message).toEqual('Jobs listing fetched successfully');
       expect(jobs.status_code).toEqual(200);
+    });
+  });
+
+  describe('deleteJob', () => {
+    it('should delete the job successfully', async () => {
+      const result = await service.delete('job-1');
+      expect(result.status).toEqual('success');
+      expect(result.message).toEqual('Job details deleted successfully');
     });
   });
 });


### PR DESCRIPTION
## What does this PR do?
The PR adds a feature for authenticated users to create and delete job listings.

## How should this be manually tested?
Send a POST request to this endpoint:

**DELETE** `/api/v1/jobs/{id}`

**Request Params**:
- `id`: The Job ID of the job to delete 

**Request Headers**:
```json
{
   "Authorization": "Bearer <token>"
}
```

**Request Response**
- Example Success Response (200):

```json
{
  "status": "success",
  "message": "Job details deleted successfully",
  "status_code": 200
}
```

- Error Response (404):
```json
{
  "message": "Job not found",
  "error": "Not Found",
  "statusCode": 404
}
```
- Error Response (401):
```json
{
  "message": "User is currently unauthorized, kindly authenticate to continue",
  "status_code": 401
}
```

## Checklist of what you did
 - [x] Ensure that only authenticated users can delete a job listing.
 - [x] Added necessary documentation. 

## Test Screenshot
![image](https://github.com/user-attachments/assets/a52fa3c0-a2e4-47b1-a771-6eec9d11b148)

## Reference Issue
https://github.com/hngprojects/hng_boilerplate_nestjs/issues/348