### PR TITLE
fix: create job error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
       "devDependencies": {
         "@commitlint/cli": "^19.3.0",
         "@commitlint/config-conventional": "^19.2.2",
+        "@golevelup/ts-jest": "^0.5.0",
         "@nestjs-modules/mailer": "^2.0.2",
         "@nestjs/cli": "^10.0.0",
         "@nestjs/common": "^10.3.10",
@@ -1256,6 +1257,12 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
         "npm": ">=6.14.13"
       }
+    },
+    "node_modules/@golevelup/ts-jest": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@golevelup/ts-jest/-/ts-jest-0.5.0.tgz",
+      "integrity": "sha512-UniUNOBraDD8vf6QNUPkpWMzhUXBtw40nCHekgBlaHy2p99MDV0aYLp4ZXifiyPOsFmg4BZQGs60lF6EpV7JpA==",
+      "dev": true
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^19.2.2",
+    "@golevelup/ts-jest": "^0.5.0",
     "@nestjs-modules/mailer": "^2.0.2",
     "@nestjs/cli": "^10.0.0",
     "@nestjs/common": "^10.3.10",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
   "devDependencies": {
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^19.2.2",
-    "@golevelup/ts-jest": "^0.5.0",
     "@nestjs-modules/mailer": "^2.0.2",
     "@nestjs/cli": "^10.0.0",
     "@nestjs/common": "^10.3.10",

--- a/src/guards/authorization.guard.ts
+++ b/src/guards/authorization.guard.ts
@@ -4,7 +4,6 @@ import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserType } from '../modules/user/entities/user.entity';
 import { Organisation } from './../modules/organisations/entities/organisations.entity';
-import { Job } from '../modules/jobs/entities/job.entity';
 
 @Injectable()
 export class OwnershipGuard implements CanActivate {

--- a/src/modules/jobs/dto/job.dto.ts
+++ b/src/modules/jobs/dto/job.dto.ts
@@ -2,7 +2,7 @@ import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
 import { IsString, IsEnum, IsBoolean, IsNotEmpty, IsOptional, IsDateString } from 'class-validator';
 
 // Enum definitions for clarity
-enum SalaryRange {
+export enum SalaryRange {
   'below_30k' = 'below_30k',
   '30k_to_50k' = '30k_to_50k',
   '50k_to_70k' = '50k_to_70k',
@@ -11,14 +11,14 @@ enum SalaryRange {
   'above_150k' = 'above_150k',
 }
 
-enum JobType {
+export enum JobType {
   FullTime = 'full-time',
   PartTime = 'part-time',
   Internship = 'internship',
   Contract = 'contract',
 }
 
-enum JobMode {
+export enum JobMode {
   Remote = 'remote',
   Onsite = 'onsite',
 }
@@ -63,6 +63,7 @@ export class JobDto {
   @ApiProperty({
     description: 'The salary range for the job',
     enum: SalaryRange,
+    type: SalaryRange,
     example: SalaryRange['30K_to_50K'],
     required: true,
   })
@@ -73,6 +74,7 @@ export class JobDto {
   @ApiProperty({
     description: 'The type of job',
     enum: JobType,
+    type: JobType,
     example: JobType['full_time'],
     required: true,
   })
@@ -83,6 +85,7 @@ export class JobDto {
   @ApiProperty({
     description: 'The mode of the job (e.g., remote, onsite)',
     enum: JobMode,
+    type: JobMode,
     example: JobMode['remote'],
     required: true,
   })

--- a/src/modules/jobs/entities/job.entity.ts
+++ b/src/modules/jobs/entities/job.entity.ts
@@ -2,6 +2,7 @@ import { AbstractBaseEntity } from './../../../entities/base.entity';
 import { User } from '../../user/entities/user.entity';
 import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
 import { ApiHideProperty } from '@nestjs/swagger';
+import { JobMode, JobType, SalaryRange } from '../dto/job.dto';
 
 @Entity()
 export class Job extends AbstractBaseEntity {
@@ -19,20 +20,20 @@ export class Job extends AbstractBaseEntity {
 
   @Column({
     type: 'enum',
-    enum: ['below_30k', '30k_to_50k', '50k_to_70k', '70k_to_100k', '100k_to_150k', 'Above_150k'],
+    enum: SalaryRange,
     nullable: false,
   })
   salary_range: string;
 
   @Column({
     type: 'enum',
-    enum: ['full-time', 'part-time', 'internship', 'contract'],
+    enum: JobType,
     default: 'full-time',
     nullable: false,
   })
   job_type: string;
 
-  @Column({ type: 'enum', enum: ['remote', 'onsite'], default: 'remote', nullable: false })
+  @Column({ type: 'enum', enum: JobMode, default: 'remote', nullable: false })
   job_mode: string;
 
   @Column('text', { nullable: false })

--- a/src/modules/jobs/guards/job.guard.ts
+++ b/src/modules/jobs/guards/job.guard.ts
@@ -19,7 +19,7 @@ export class JobGuard implements CanActivate {
       relations: ['user'],
     });
 
-    if (job.user.id === user.sub) {
+    if (job.user.id === user.id) {
       if (!job || job.is_deleted === true) throw new NotFoundException('Job not found');
       return true;
     } else {

--- a/src/modules/jobs/jobs.controller.ts
+++ b/src/modules/jobs/jobs.controller.ts
@@ -41,6 +41,9 @@ export class JobsController {
 
   @UseGuards(JobGuard)
   @Delete('/:id')
+  @ApiResponse({ status: 200, description: 'Job deleted successfully' })
+  @ApiResponse({ status: 403, description: 'You do not have permission to perform this action' })
+  @ApiResponse({ status: 404, description: 'Job not found' })
   async delete(@Param('id') id: string) {
     return this.jobService.delete(id);
   }

--- a/src/modules/jobs/jobs.controller.ts
+++ b/src/modules/jobs/jobs.controller.ts
@@ -41,6 +41,7 @@ export class JobsController {
 
   @UseGuards(JobGuard)
   @Delete('/:id')
+  @ApiOperation({ summary: 'Delete a job' })
   @ApiResponse({ status: 200, description: 'Job deleted successfully' })
   @ApiResponse({ status: 403, description: 'You do not have permission to perform this action' })
   @ApiResponse({ status: 404, description: 'Job not found' })

--- a/src/modules/jobs/jobs.controller.ts
+++ b/src/modules/jobs/jobs.controller.ts
@@ -3,8 +3,8 @@ import { JobsService } from './jobs.service';
 import { JobDto } from './dto/job.dto';
 import { PaginationDto } from './dto/pagination.dto';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { skipAuth } from '../../helpers/skipAuth';
 import { JobGuard } from './guards/job.guard';
+import { skipAuth } from '../../helpers/skipAuth';
 
 @ApiTags('Jobs')
 @ApiBearerAuth()

--- a/src/modules/jobs/jobs.controller.ts
+++ b/src/modules/jobs/jobs.controller.ts
@@ -4,6 +4,7 @@ import { JobDto } from './dto/job.dto';
 import { PaginationDto } from './dto/pagination.dto';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { skipAuth } from '../../helpers/skipAuth';
+import { JobGuard } from './guards/job.guard';
 
 @ApiTags('Jobs')
 @ApiBearerAuth()
@@ -36,5 +37,11 @@ export class JobsController {
   @ApiResponse({ status: 404, description: 'Job not found' })
   async getJob(@Param('id') id: string) {
     return this.jobService.getJob(id);
+  }
+
+  @UseGuards(JobGuard)
+  @Delete('/:id')
+  async delete(@Param('id') id: string) {
+    return this.jobService.delete(id);
   }
 }

--- a/src/modules/jobs/jobs.service.ts
+++ b/src/modules/jobs/jobs.service.ts
@@ -69,4 +69,23 @@ export class JobsService {
       data: job,
     };
   }
+  async delete(jobId: string) {
+    // Check if listing exists
+    const job = await this.jobRepository.findOne({
+      where: { id: jobId },
+    });
+
+    job.is_deleted = true;
+    const deleteJobEntityInstance = this.jobRepository.create(job);
+
+    // Save the new Job entity to the database
+    await this.jobRepository.save(deleteJobEntityInstance);
+
+    // Return a success response
+    return {
+      status: 'success',
+      message: 'Job details deleted successfully',
+      status_code: 200,
+    };
+  }
 }

--- a/src/modules/jobs/tests/job.guard.spec.ts
+++ b/src/modules/jobs/tests/job.guard.spec.ts
@@ -1,0 +1,86 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { JobGuard } from '../../../guards/authorization.guard'; // Adjust the import path as necessary
+import { Repository } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Job } from '../entities/job.entity';
+import { createMock } from '@golevelup/ts-jest';
+
+describe('JobGuard', () => {
+  let guard: JobGuard;
+  let jobRepository: Repository<Job>;
+
+  const mockJobRepository = {
+    findOne: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        {
+          provide: getRepositoryToken(Job),
+          useValue: mockJobRepository,
+        },
+      ],
+    }).compile();
+
+    jobRepository = module.get<Repository<Job>>(getRepositoryToken(Job));
+    guard = new JobGuard(jobRepository);
+  });
+
+  it('should allow access if the job belongs to the user', async () => {
+    const mockJob = { id: '1', user: { id: 'user123' }, is_deleted: false } as Job;
+    mockJobRepository.findOne.mockResolvedValue(mockJob);
+    const mockContext = createMock<ExecutionContext>();
+
+    mockContext.switchToHttp().getRequest.mockReturnValue({
+      user: { sub: 'user123' },
+      params: { id: 1 },
+    });
+    const result = await guard.canActivate(mockContext);
+
+    expect(result).toBe(true);
+  });
+
+  it('should throw NotFoundException if the job is deleted', async () => {
+    const mockJob = { id: '1', user: { id: 'user123' }, is_deleted: true } as Job;
+    mockJobRepository.findOne.mockResolvedValue(mockJob);
+
+    const mockContext = createMock<ExecutionContext>();
+
+    mockContext.switchToHttp().getRequest.mockReturnValue({
+      user: { sub: 'user123' },
+      params: { id: 1 },
+    });
+
+    await expect(guard.canActivate(mockContext)).rejects.toThrow(NotFoundException);
+  });
+
+  it('should throw ForbiddenException if the job does not belong to the user', async () => {
+    const mockJob = { id: '1', user: { id: 'user456' }, is_deleted: false } as Job;
+    mockJobRepository.findOne.mockResolvedValue(mockJob);
+
+    const mockContext = createMock<ExecutionContext>();
+
+    mockContext.switchToHttp().getRequest.mockReturnValue({
+      user: { sub: 'user123' },
+      params: { id: 1 },
+    });
+
+    await expect(guard.canActivate(mockContext)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('should throw NotFoundException if the job is not found', async () => {
+    const mockJob = { id: '1', user: { id: 'user456' }, is_deleted: true } as Job;
+    mockJobRepository.findOne.mockResolvedValue(mockJob);
+
+    const mockContext = createMock<ExecutionContext>();
+
+    mockContext.switchToHttp().getRequest.mockReturnValue({
+      user: { sub: 'user456' },
+      params: { id: 1 },
+    });
+
+    await expect(guard.canActivate(mockContext)).rejects.toThrow(NotFoundException);
+  });
+});

--- a/src/modules/jobs/tests/job.guard.spec.ts
+++ b/src/modules/jobs/tests/job.guard.spec.ts
@@ -34,7 +34,7 @@ describe('JobGuard', () => {
     const mockContext = createMock<ExecutionContext>();
 
     mockContext.switchToHttp().getRequest.mockReturnValue({
-      user: { sub: 'user123' },
+      user: { id: 'user123' },
       params: { id: 1 },
     });
     const result = await guard.canActivate(mockContext);
@@ -49,7 +49,7 @@ describe('JobGuard', () => {
     const mockContext = createMock<ExecutionContext>();
 
     mockContext.switchToHttp().getRequest.mockReturnValue({
-      user: { sub: 'user123' },
+      user: { id: 'user123' },
       params: { id: 1 },
     });
 
@@ -63,7 +63,7 @@ describe('JobGuard', () => {
     const mockContext = createMock<ExecutionContext>();
 
     mockContext.switchToHttp().getRequest.mockReturnValue({
-      user: { sub: 'user123' },
+      user: { id: 'user123' },
       params: { id: 1 },
     });
 
@@ -77,7 +77,7 @@ describe('JobGuard', () => {
     const mockContext = createMock<ExecutionContext>();
 
     mockContext.switchToHttp().getRequest.mockReturnValue({
-      user: { sub: 'user456' },
+      user: { id: 'user456' },
       params: { id: 1 },
     });
 

--- a/src/modules/jobs/tests/job.guard.spec.ts
+++ b/src/modules/jobs/tests/job.guard.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ExecutionContext, ForbiddenException, NotFoundException } from '@nestjs/common';
-import { JobGuard } from '../../../guards/authorization.guard'; // Adjust the import path as necessary
+import { JobGuard } from '../guards/job.guard';
 import { Repository } from 'typeorm';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Job } from '../entities/job.entity';

--- a/src/modules/jobs/tests/job.guard.spec.ts
+++ b/src/modules/jobs/tests/job.guard.spec.ts
@@ -4,7 +4,6 @@ import { JobGuard } from '../guards/job.guard';
 import { Repository } from 'typeorm';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Job } from '../entities/job.entity';
-import { createMock } from '@golevelup/ts-jest';
 
 describe('JobGuard', () => {
   let guard: JobGuard;
@@ -31,12 +30,16 @@ describe('JobGuard', () => {
   it('should allow access if the job belongs to the user', async () => {
     const mockJob = { id: '1', user: { id: 'user123' }, is_deleted: false } as Job;
     mockJobRepository.findOne.mockResolvedValue(mockJob);
-    const mockContext = createMock<ExecutionContext>();
 
-    mockContext.switchToHttp().getRequest.mockReturnValue({
-      user: { id: 'user123' },
-      params: { id: 1 },
-    });
+    const mockContext = {
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          user: { id: 'user123' },
+          params: { id: 1 },
+        }),
+      }),
+    } as unknown as ExecutionContext;
+
     const result = await guard.canActivate(mockContext);
 
     expect(result).toBe(true);
@@ -46,12 +49,14 @@ describe('JobGuard', () => {
     const mockJob = { id: '1', user: { id: 'user123' }, is_deleted: true } as Job;
     mockJobRepository.findOne.mockResolvedValue(mockJob);
 
-    const mockContext = createMock<ExecutionContext>();
-
-    mockContext.switchToHttp().getRequest.mockReturnValue({
-      user: { id: 'user123' },
-      params: { id: 1 },
-    });
+    const mockContext = {
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          user: { id: 'user123' },
+          params: { id: 1 },
+        }),
+      }),
+    } as unknown as ExecutionContext;
 
     await expect(guard.canActivate(mockContext)).rejects.toThrow(NotFoundException);
   });
@@ -60,12 +65,14 @@ describe('JobGuard', () => {
     const mockJob = { id: '1', user: { id: 'user456' }, is_deleted: false } as Job;
     mockJobRepository.findOne.mockResolvedValue(mockJob);
 
-    const mockContext = createMock<ExecutionContext>();
-
-    mockContext.switchToHttp().getRequest.mockReturnValue({
-      user: { id: 'user123' },
-      params: { id: 1 },
-    });
+    const mockContext = {
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          user: { id: 'user123' },
+          params: { id: 1 },
+        }),
+      }),
+    } as unknown as ExecutionContext;
 
     await expect(guard.canActivate(mockContext)).rejects.toThrow(ForbiddenException);
   });
@@ -74,12 +81,14 @@ describe('JobGuard', () => {
     const mockJob = { id: '1', user: { id: 'user456' }, is_deleted: true } as Job;
     mockJobRepository.findOne.mockResolvedValue(mockJob);
 
-    const mockContext = createMock<ExecutionContext>();
-
-    mockContext.switchToHttp().getRequest.mockReturnValue({
-      user: { id: 'user456' },
-      params: { id: 1 },
-    });
+    const mockContext = {
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          user: { id: 'user456' },
+          params: { id: 1 },
+        }),
+      }),
+    } as unknown as ExecutionContext;
 
     await expect(guard.canActivate(mockContext)).rejects.toThrow(NotFoundException);
   });

--- a/src/modules/jobs/tests/jobs.service.spec.ts
+++ b/src/modules/jobs/tests/jobs.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { JobsService } from '../jobs.service';
 import { JobDto } from '../dto/job.dto';
-import { Repository } from 'typeorm';
+import { DeleteResult, Repository } from 'typeorm';
 import { Job } from '../entities/job.entity';
 import UserResponseDTO from '../../user/dto/user-response.dto';
 import { User } from '../../user/entities/user.entity';
@@ -12,8 +12,27 @@ describe('JobsService', () => {
   let service: JobsService;
   let jobRepository: Repository<Job>;
   let userRepository: Repository<User>;
+  let userDto: UserResponseDTO;
+  let createJobDto: JobDto;
 
   beforeEach(async () => {
+    userDto = {
+      id: 'user_id',
+      email: 'test@example.com',
+    };
+
+    createJobDto = {
+      title: 'Software Engineer II',
+      description:
+        'We are looking for a skilled Software Engineer to join our team. The ideal candidate will have experience in building high-performance applications.',
+      location: 'New York, NY',
+      deadline: '2024-12-31T23:59:59Z',
+      salary_range: '70k_to_100k',
+      job_type: 'full-time',
+      job_mode: 'remote',
+      company_name: 'Tech Innovators Inc.',
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         JobsService,
@@ -46,6 +65,13 @@ describe('JobsService', () => {
     service = module.get<JobsService>(JobsService);
     userRepository = module.get(getRepositoryToken(User));
     jobRepository = module.get(getRepositoryToken(Job));
+
+    jest.spyOn(userRepository, 'findOne').mockResolvedValue(userDto as User);
+    jest.spyOn(jobRepository, 'create').mockReturnValue({ ...createJobDto, user: userDto } as Job);
+    jest
+      .spyOn(jobRepository, 'findOne')
+      .mockResolvedValue({ ...createJobDto, is_deleted: false, user: userDto } as Job);
+    jest.spyOn(jobRepository, 'save').mockResolvedValue({ ...createJobDto } as Job);
   });
 
   it('should be defined', () => {
@@ -53,26 +79,7 @@ describe('JobsService', () => {
   });
 
   describe('createNewJob', () => {
-    const userDto: UserResponseDTO = {
-      id: 'user_id',
-      email: 'test@example.com',
-    };
-    const createJobDto: JobDto = {
-      title: 'Software Engineer II',
-      description:
-        'We are looking for a skilled Software Engineer to join our team. The ideal candidate will have experience in building high-performance applications.',
-      location: 'New York, NY',
-      deadline: '2024-12-31T23:59:59Z',
-      salary_range: '70k_to_100k',
-      job_type: 'full-time',
-      job_mode: 'remote',
-      company_name: 'Tech Innovators Inc.',
-    };
-
     it('should create a new job successfully', async () => {
-      jest.spyOn(userRepository, 'findOne').mockResolvedValue(userDto as User);
-      jest.spyOn(jobRepository, 'create').mockReturnValue({ ...createJobDto, user: userDto } as Job);
-      jest.spyOn(jobRepository, 'save').mockResolvedValue({ ...createJobDto } as Job);
       const result = await service.create(createJobDto, userDto.id);
       expect(result.status).toEqual('success');
       expect(result.message).toEqual('Job listing created successfully');
@@ -86,6 +93,14 @@ describe('JobsService', () => {
       const jobs = await service.getJobs();
       expect(jobs.message).toEqual('Jobs listing fetched successfully');
       expect(jobs.status_code).toEqual(200);
+    });
+  });
+
+  describe('deleteJob', () => {
+    it('should delete the job successfully', async () => {
+      const result = await service.delete('job-1');
+      expect(result.status).toEqual('success');
+      expect(result.message).toEqual('Job details deleted successfully');
     });
   });
 });


### PR DESCRIPTION
**Issue**: The job creation process encountered an error due to incorrect input data handling. Inputs with salary ranges above 150k were causing internal server errors.

This was causing failures in creating new job listings and impacting the user experience.

**Changes Made**:
- [x] Fixed the bug in the job creation logic.
- [x] Improved input validation to ensure all required fields are correctly handled.

**Test Screenshots**:

![image](https://github.com/user-attachments/assets/dc73c88e-c153-435e-9c82-c50d95a54418)

**Notes**:
- Ensure review of the changes in `job.dto.ts` and `job.entity.ts` for the specific updates in handling job creation.

Please review the changes and provide feedback.
