### PR TITLE
feat: API Endpoint to Fetch All Roles within an Organisation

### DIFF
--- a/src/modules/organisation-role/dto/create-organisation-role.dto.ts
+++ b/src/modules/organisation-role/dto/create-organisation-role.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, MaxLength, IsOptional } from 'class-validator';
+
+export class CreateOrganisationRoleDto {
+  @ApiProperty({ description: 'The name of the role', maxLength: 50 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  name: string;
+
+  @ApiProperty({ description: 'The description of the role', maxLength: 200 })
+  @IsString()
+  @IsOptional()
+  @MaxLength(200)
+  description?: string;
+}

--- a/src/modules/organisation-role/dto/update-organisation-role.dto.ts
+++ b/src/modules/organisation-role/dto/update-organisation-role.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateOrganisationRoleDto } from './create-organisation-role.dto';
+
+export class UpdateOrganisationRoleDto extends PartialType(CreateOrganisationRoleDto) {}

--- a/src/modules/organisation-role/entities/organisation-role.entity.ts
+++ b/src/modules/organisation-role/entities/organisation-role.entity.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AbstractBaseEntity } from '../../../entities/base.entity';
+import { Column, Entity } from 'typeorm';
+
+@Entity('roles')
+export class OrganisationRole extends AbstractBaseEntity {
+  @ApiProperty({ description: 'The ID of the role' })
+  @Column({ nullable: false })
+  id: string;
+
+  @ApiProperty({ description: 'The name of the role', maxLength: 50 })
+  @Column({ length: 50, unique: true, nullable: false })
+  name: string;
+
+  @ApiProperty({ description: 'The description of the role', maxLength: 200, required: false })
+  @Column({ length: 200, nullable: true })
+  description: string;
+}

--- a/src/modules/organisation-role/organisation-role.controller.ts
+++ b/src/modules/organisation-role/organisation-role.controller.ts
@@ -1,0 +1,46 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete, HttpCode, HttpStatus, UseGuards } from '@nestjs/common';
+import { OrganisationRoleService } from './organisation-role.service';
+import { UpdateOrganisationRoleDto } from './dto/update-organisation-role.dto';
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { OwnershipGuard } from '../../guards/authorization.guard';
+import { AuthGuard } from '../../guards/auth.guard';
+
+@ApiTags('Organisation Settings')
+@ApiBearerAuth()
+@Controller('organisation/')
+export class OrganisationRoleController {
+  constructor(private readonly organisationRoleService: OrganisationRoleService) {}
+
+  @Get(':org_id/roles')
+  @UseGuards(AuthGuard, OwnershipGuard)
+  @ApiOperation({ summary: 'Get all organisation roles' })
+  @ApiResponse({ status: 200, description: 'Success', type: [Object] })
+  @ApiResponse({ status: 404, description: 'Organisation not found' })
+  async getRoles(@Param('organisationId') organisationID: string) {
+    const roles = await this.organisationRoleService.getAllRolesInOrg(organisationID);
+    return {
+      status_code: 200,
+      data: roles,
+    };
+  }
+
+  @Get()
+  findAll() {
+    return this.organisationRoleService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.organisationRoleService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateOrganisationRoleDto: UpdateOrganisationRoleDto) {
+    return this.organisationRoleService.update(+id, updateOrganisationRoleDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.organisationRoleService.remove(+id);
+  }
+}

--- a/src/modules/organisation-role/organisation-role.module.ts
+++ b/src/modules/organisation-role/organisation-role.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { OrganisationRoleService } from './organisation-role.service';
+import { OrganisationRoleController } from './organisation-role.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { OrganisationRole } from './entities/organisation-role.entity';
+import { Organisation } from '../organisations/entities/organisations.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([OrganisationRole, Organisation])],
+  controllers: [OrganisationRoleController],
+  providers: [OrganisationRoleService],
+})
+export class OrganisationRoleModule {}

--- a/src/modules/organisation-role/organisation-role.service.ts
+++ b/src/modules/organisation-role/organisation-role.service.ts
@@ -1,0 +1,51 @@
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { CreateOrganisationRoleDto } from './dto/create-organisation-role.dto';
+import { UpdateOrganisationRoleDto } from './dto/update-organisation-role.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { OrganisationRole } from './entities/organisation-role.entity';
+import { Organisation } from '../organisations/entities/organisations.entity';
+
+@Injectable()
+export class OrganisationRoleService {
+  constructor(
+    @InjectRepository(OrganisationRole)
+    private rolesRepository: Repository<OrganisationRole>,
+    @InjectRepository(Organisation)
+    private organisationRepository: Repository<Organisation>
+  ) {}
+
+  async getAllRolesInOrg(organisationID: string) {
+    const organisation = await this.organisationRepository.findOne({
+      where: { id: organisationID },
+      relations: ['roles'],
+    });
+    if (!organisation) {
+      throw new NotFoundException('Organisation not found');
+    }
+
+    return this.rolesRepository.find().then(roles =>
+      roles.map(role => ({
+        id: role.id,
+        name: role.name,
+        description: role.description,
+      }))
+    );
+  }
+
+  findAll() {
+    return `This action returns all organisationRole`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} organisationRole`;
+  }
+
+  update(id: number, updateOrganisationRoleDto: UpdateOrganisationRoleDto) {
+    return `This action updates a #${id} organisationRole`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} organisationRole`;
+  }
+}

--- a/src/modules/organisation-role/test/orgainisation-role.serviec.spec.ts
+++ b/src/modules/organisation-role/test/orgainisation-role.serviec.spec.ts
@@ -1,0 +1,77 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Repository } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { OrganisationRoleService } from '../organisation-role.service';
+import { OrganisationRole } from '../entities/organisation-role.entity';
+import { Organisation } from '../../organisations/entities/organisations.entity';
+import { NotFoundException } from '@nestjs/common';
+
+describe('OrganisationRoleService', () => {
+  let service: OrganisationRoleService;
+  let rolesRepository: Repository<OrganisationRole>;
+  let organisationRepository: Repository<Organisation>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrganisationRoleService,
+        {
+          provide: getRepositoryToken(OrganisationRole),
+          useClass: Repository,
+        },
+        {
+          provide: getRepositoryToken(Organisation),
+          useClass: Repository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<OrganisationRoleService>(OrganisationRoleService);
+    rolesRepository = module.get<Repository<OrganisationRole>>(getRepositoryToken(OrganisationRole));
+    organisationRepository = module.get<Repository<Organisation>>(getRepositoryToken(Organisation));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getAllRolesInOrganisation', () => {
+    it('should return an array of roles for an existing organization', async () => {
+      const organisationId = '1';
+      const mockRoles = [
+        { id: '1', name: 'Admin', description: 'Administrator role' },
+        { id: '2', name: 'User', description: 'Regular user role' },
+      ];
+
+      jest.spyOn(organisationRepository, 'findOne').mockResolvedValue({ id: organisationId } as Organisation);
+      jest.spyOn(rolesRepository, 'find').mockResolvedValue(mockRoles as OrganisationRole[]);
+
+      const roles = await service.getAllRolesInOrg(organisationId);
+      expect(roles).toEqual(mockRoles);
+    });
+
+    it('should throw NotFoundException if the organisation is not found', async () => {
+      const organisationId = '1';
+      jest.spyOn(organisationRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(service.getAllRolesInOrg(organisationId)).rejects.toThrow(NotFoundException);
+    });
+    it('should handle cases where roles are not available', async () => {
+      const organisationId = '1';
+
+      jest.spyOn(organisationRepository, 'findOne').mockResolvedValue({ id: organisationId } as Organisation);
+      jest.spyOn(rolesRepository, 'find').mockResolvedValue([]);
+
+      const roles = await service.getAllRolesInOrg(organisationId);
+      expect(roles).toEqual([]);
+    });
+
+    it('should handle database errors gracefully', async () => {
+      const organisationId = '1';
+
+      jest.spyOn(organisationRepository, 'findOne').mockRejectedValue(new Error('Database error'));
+
+      await expect(service.getAllRolesInOrg(organisationId)).rejects.toThrowError('Database error');
+    });
+  });
+});


### PR DESCRIPTION
## Description:
This PR introduces a new endpoint to retrieve all roles in an organization. 

## How should this be manually tested?
Send a GET request to `/api/v1/organisation/{org_id}/roles`.

## Checklist of what you did:
Implement GET `/api/v1/organisation/{org_id}/roles` endpoint
- [x] Use OrganizationGuard to extract and validate organisation context
- [x] Ensure authentication using JWT tokens
- [x] Authorize users based on their permissions within the organization
- [x] Write unit tests for the role fetching endpoint

## Reference Issues
[FEAT] API Endpoint to Fetch All Roles within an Organisation. #288