### PR TITLE
feat : faq crud operations

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -14,8 +14,8 @@
 # even if you have the "PROFILE" variable in your ".env.local" file.
 
 
-PROFILE=local
-NODE_ENV=development
+# PROFILE=local
+# NODE_ENV=development
 
 
 PORT=3008

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,14 +10,9 @@
     "statusBar.background": "#1a1f15",
     "statusBarItem.hoverBackground": "#333d2a",
     "statusBar.foreground": "#e7e7e7",
-    "commandCenter.border": "#e7e7e799",
-    "sash.hoverBorder": "#333d2a",
-    "statusBarItem.remoteBackground": "#1a1f15",
-    "statusBarItem.remoteForeground": "#e7e7e7",
-    "titleBar.activeBackground": "#1a1f15",
-    "titleBar.activeForeground": "#e7e7e7",
-    "titleBar.inactiveBackground": "#1a1f1599",
-    "titleBar.inactiveForeground": "#e7e7e799"
+    "panel.border": "#333d2a",
+    "sideBar.border": "#333d2a",
+    "editorGroup.border": "#333d2a"
   },
   "peacock.color": "#1a1f15",
   "eslint.validate": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,9 +10,14 @@
     "statusBar.background": "#1a1f15",
     "statusBarItem.hoverBackground": "#333d2a",
     "statusBar.foreground": "#e7e7e7",
-    "panel.border": "#333d2a",
-    "sideBar.border": "#333d2a",
-    "editorGroup.border": "#333d2a"
+    "commandCenter.border": "#e7e7e799",
+    "sash.hoverBorder": "#333d2a",
+    "statusBarItem.remoteBackground": "#1a1f15",
+    "statusBarItem.remoteForeground": "#e7e7e7",
+    "titleBar.activeBackground": "#1a1f15",
+    "titleBar.activeForeground": "#e7e7e7",
+    "titleBar.inactiveBackground": "#1a1f1599",
+    "titleBar.inactiveForeground": "#e7e7e799"
   },
   "peacock.color": "#1a1f15",
   "eslint.validate": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
       "devDependencies": {
         "@commitlint/cli": "^19.3.0",
         "@commitlint/config-conventional": "^19.2.2",
-        "@golevelup/ts-jest": "^0.5.0",
         "@nestjs-modules/mailer": "^2.0.2",
         "@nestjs/cli": "^10.0.0",
         "@nestjs/common": "^10.3.10",
@@ -1257,12 +1256,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
         "npm": ">=6.14.13"
       }
-    },
-    "node_modules/@golevelup/ts-jest": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@golevelup/ts-jest/-/ts-jest-0.5.0.tgz",
-      "integrity": "sha512-UniUNOBraDD8vf6QNUPkpWMzhUXBtw40nCHekgBlaHy2p99MDV0aYLp4ZXifiyPOsFmg4BZQGs60lF6EpV7JpA==",
-      "dev": true
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",

--- a/src/modules/faq/faq.controller.spec.ts
+++ b/src/modules/faq/faq.controller.spec.ts
@@ -5,6 +5,7 @@ import { FaqController } from './faq.controller';
 import { CreateFaqDto } from './create-faq.dto';
 import { IFaq, ICreateFaqResponse } from './faq.interface';
 
+
 describe('FaqController (e2e)', () => {
   let app;
   let server;

--- a/src/modules/faq/faq.controller.ts
+++ b/src/modules/faq/faq.controller.ts
@@ -1,9 +1,11 @@
-import { Controller, Post, Body, UsePipes, ValidationPipe } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Controller, Post, Body, UsePipes, ValidationPipe, Get, Put, Param, Delete } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { FaqService } from './faq.service';
 import { CreateFaqDto } from './create-faq.dto';
 import { Faq } from './faq.entity';
 import { ICreateFaqResponse, IFaq } from './faq.interface';
+import { skipAuth } from '../../helpers/skipAuth';
+import { UpdateFaqDto } from './update-faq.dto';
 
 @ApiTags('faqs')
 @Controller('faqs')
@@ -33,5 +35,29 @@ export class FaqController {
       success: true,
       data: faq,
     };
+  }
+  @skipAuth()
+  @Get()
+  @ApiOperation({ summary: 'Get all frequently asked questions' })
+  async findAll() {
+    return this.faqService.findAllFaq();
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: 'Update an existing FAQ' })
+  @ApiParam({ name: 'id', type: 'string' })
+  @ApiResponse({ status: 200, description: 'The FAQ has been successfully updated.', type: Faq })
+  @ApiResponse({ status: 400, description: 'Bad Request.' })
+  async update(@Param('id') id: string, @Body() updateFaqDto: UpdateFaqDto) {
+    return this.faqService.updateFaq(id, updateFaqDto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete an FAQ' })
+  @ApiParam({ name: 'id', type: 'string' })
+  @ApiResponse({ status: 200, description: 'The FAQ has been successfully deleted.' })
+  @ApiResponse({ status: 400, description: 'Bad Request.' })
+  async remove(@Param('id') id: string) {
+    return this.faqService.removeFaq(id);
   }
 }

--- a/src/modules/faq/faq.service.spec.ts
+++ b/src/modules/faq/faq.service.spec.ts
@@ -1,0 +1,106 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { FaqService } from './faq.service';
+import { Faq } from './faq.entity';
+import { BadRequestException } from '@nestjs/common';
+
+describe('FaqService', () => {
+  let service: FaqService;
+  let repository: Repository<Faq>;
+
+  const mockRepository = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    save: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FaqService,
+        {
+          provide: getRepositoryToken(Faq),
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<FaqService>(FaqService);
+    repository = module.get<Repository<Faq>>(getRepositoryToken(Faq));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findAll', () => {
+    it('should return an array of FAQs', async () => {
+      const mockFaqs = [
+        { id: '1', question: 'Q1', answer: 'A1', category: 'C1' },
+        { id: '2', question: 'Q2', answer: 'A2', category: 'C2' },
+      ];
+      mockRepository.find.mockResolvedValue(mockFaqs);
+
+      const result = await service.findAllFaq();
+
+      expect(result).toEqual({
+      
+        data: mockFaqs
+      ,
+      message: "Faq fetched successfully",
+      status_code: 200
+    });
+      expect(mockRepository.find).toHaveBeenCalled();
+    });
+  });
+
+  describe('update', () => {
+    it('should update and return a FAQ', async () => {
+      const id = '1';
+      const updateFaqDto = { question: 'Updated Q', answer: 'Updated A', category: 'Updated C' };
+      const existingFaq = { id, question: 'Q', answer: 'A', category: 'C' };
+      const updatedFaq = { ...existingFaq, ...updateFaqDto };
+
+      mockRepository.findOne.mockResolvedValue(existingFaq);
+      mockRepository.save.mockResolvedValue(updatedFaq);
+
+      const result = await service.updateFaq(id, updateFaqDto);
+
+      expect(result).toEqual(updatedFaq);
+      expect(mockRepository.findOne).toHaveBeenCalledWith({ where: { id } });
+      expect(mockRepository.save).toHaveBeenCalledWith(updatedFaq);
+    });
+
+    it('should throw BadRequestException if FAQ not found', async () => {
+      const id = '1';
+      const updateFaqDto = { question: 'Updated Q' };
+
+      mockRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.updateFaq(id, updateFaqDto)).rejects.toThrow(BadRequestException);
+      expect(mockRepository.findOne).toHaveBeenCalledWith({ where: { id } });
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a FAQ and return success message', async () => {
+      const id = '1';
+      mockRepository.delete.mockResolvedValue({ affected: 1 });
+
+      const result = await service.removeFaq(id);
+
+      expect(result).toEqual({ message: 'FAQ successfully deleted' });
+      expect(mockRepository.delete).toHaveBeenCalledWith(id);
+    });
+
+    it('should throw BadRequestException if FAQ not found', async () => {
+      const id = '1';
+      mockRepository.delete.mockResolvedValue({ affected: 0 });
+
+      await expect(service.removeFaq(id)).rejects.toThrow(BadRequestException);
+      expect(mockRepository.delete).toHaveBeenCalledWith(id);
+    });
+  });
+});

--- a/src/modules/faq/faq.service.ts
+++ b/src/modules/faq/faq.service.ts
@@ -1,9 +1,10 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, InternalServerErrorException, UnauthorizedException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Faq } from './faq.entity';
 import { CreateFaqDto } from './create-faq.dto';
 import { IFaq } from './faq.interface';
+import { UpdateFaqDto } from './update-faq.dto';
 
 @Injectable()
 export class FaqService {
@@ -15,5 +16,71 @@ export class FaqService {
   async create(createFaqDto: CreateFaqDto): Promise<IFaq> {
     const faq = this.faqRepository.create(createFaqDto);
     return this.faqRepository.save(faq);
+  }
+   async findAllFaq() {
+    try {
+      const faqs = await this.faqRepository.find();
+      return {
+        message: 'Faq fetched successfully',
+        status_code: 200,
+        data: faqs,
+      };
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        return {
+          message: 'Invalid request',
+          status_code: 400,
+        };
+      } else if (error instanceof InternalServerErrorException) {
+        throw error;
+      }
+    }
+  }
+
+  async updateFaq(id: string, updateFaqDto: UpdateFaqDto) {
+    
+      const faq = await this.faqRepository.findOne({ where: { id } });
+      if (!faq) {
+      throw new BadRequestException({
+      message: 'Invalid request data',
+      status_code: 400,
+      });
+      }
+      try {
+      Object.assign(faq, updateFaqDto);
+      const updatedFaq = await this.faqRepository.save(faq);
+      return {
+        id: updatedFaq.id,
+        question: updatedFaq.question,
+        answer: updatedFaq.answer,
+        category: updatedFaq.category,
+      };
+      
+    } catch (error) {
+      if (error instanceof UnauthorizedException) {
+        return {
+          message: 'Unauthorized access',
+          status_code: 401,
+        };
+      } else if (error instanceof BadRequestException) {
+        return {
+          message: 'Invalid request data',
+          status_code: 400,
+        };
+      }
+    }
+  }
+
+  async removeFaq(id: string) {
+    const result = await this.faqRepository.delete(id);
+    if (result.affected === 0) {
+      throw new BadRequestException({
+        message: 'Invalid request',
+        status_code: 400,
+      });
+    }
+    return {
+      message: 'FAQ successfully deleted',
+    };
   }
 }

--- a/src/modules/faq/update-faq.dto.ts
+++ b/src/modules/faq/update-faq.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateFaqDto } from './create-faq.dto';
+
+export class UpdateFaqDto extends PartialType(CreateFaqDto) {}


### PR DESCRIPTION
###  What does the PR do?
This PR addresses issue #170 by implementing the get, update and delete frequently asked questions operations from the 
   database. 

### How should this be manually tested?
To test this feature, you can send a GET request to the following endpoint:
## Read FAQ :

Endpoint:
 ` GET /api/v1/faqs`
Response (Success):
```
[
  {
    "id": "String",
    "question": "String",
    "answer": "String",
    "category": "String"
  }
]
```
Response (Error - Invalid Request):
```
{
  "message": "Invalid request",
  "status_code": 400
}
```
## Update FAQ :

Endpoint:
` PUT /api/v1/faqs/{id}`
Request Body:
```
{
  "question": "String",
  "answer": "String",
  "category": "String"
}
```
Response (Success):
```
{
  "id": "String",
  "question": "String",
  "answer": "String",
  "category": "String"
}
```
Response (Error - Invalid Request):
```
{
  "message": "Invalid request data",
  "status_code": 400
}
```
Response (Authorization Error):
```
{
  "message": "Unauthorized access",
  "status_code": 403
}
```
## Delete FAQ :
 Endpoint:
`  DELETE /api/v1/faqs/{id}`
Response (Success):
```
{
  "message": "FAQ entry deleted successfully"
}
```
Response (Error - Invalid Request):
```
{
  "message": "Invalid request",
  "status_code": 400
}
```
Response (Authorization Error):
```
{
  "message": "Unauthorized access",
  "status_code": 403
}
```
### Acceptance Criteria
- [x] Implement endpoints for reading, updating, and deleting FAQ entries.
- [x] Validate input data for each operation.
- [x] updating and deleting FAQs should require admin authorization.
 `Error Handling:`
- [x] Display clear error messages for invalid inputs.
 `Security Measures:`
- [x] Validate user input on the server side.
- [x] Ensure only authenticated and authorized users can perform CRUD operations on FAQs.

Reference Issue: [[Link to Issue]](https://github.com/hngprojects/hng_boilerplate_nestjs/issues/170)