### PR TITLE
bug-fix: fix waitlist circular dependency bug.

### DIFF
--- a/src/modules/waitlist/dto/get-waitlist.dto.ts
+++ b/src/modules/waitlist/dto/get-waitlist.dto.ts
@@ -2,15 +2,17 @@ export class GetWaitlistResponseDto {
   status: number;
   status_code: number;
   message: string;
-  data: {
-    waitlist: {
-      id: string;
-      name: string;
-      email: string;
-      status: boolean;
-      url_slug?: string;
-      createdAt: Date;
-      updatedAt: Date;
-    }[];
-  };
+  data: GetWaitlistDataInterface;
+}
+
+interface GetWaitlistDataInterface {
+  waitlist: {
+    id: string;
+    name: string;
+    email: string;
+    status: boolean;
+    url_slug?: string;
+    createdAt: Date;
+    updatedAt: Date;
+  }[];
 }


### PR DESCRIPTION
**Issue:** The swagger api response type for super admin get all waitlist feature caused a circular dependency because of using nested types.

This was causing error starting the server due to the detected circular dependency issue.

Changes Made:

 Fixed the bug causing the circular dependency by creating an interface to serve as a type for the nested type.

Test Screenshots:

![image](https://github.com/user-attachments/assets/32820232-4f7a-4cd0-a02b-0933202eedb2)
