### PR TITLE
fix: organization spelling inconsistency

### DIFF
--- a/src/modules/invite/invite.controller.ts
+++ b/src/modules/invite/invite.controller.ts
@@ -1,10 +1,10 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, InternalServerErrorException } from '@nestjs/common';
-import { InviteService } from './invite.service';
+import { Controller, Get } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { InviteService } from './invite.service';
 
 @ApiBearerAuth()
 @ApiTags('Organisation Invites')
-@Controller('organizations/invitations')
+@Controller('organisations/invitations')
 export class InviteController {
   constructor(private readonly inviteService: InviteService) {}
 

--- a/src/modules/organisation-permissions/mocks/organisation.mock.ts
+++ b/src/modules/organisation-permissions/mocks/organisation.mock.ts
@@ -2,7 +2,7 @@ import { Organisation } from '../../organisations/entities/organisations.entity'
 
 export const mockOrganisation = {
   id: 'org_123',
-  name: 'Test Organization',
+  name: 'Test organisation',
   role: [
     {
       id: 'role_456',

--- a/src/modules/organisation-permissions/organisation-permissions.controller.ts
+++ b/src/modules/organisation-permissions/organisation-permissions.controller.ts
@@ -16,7 +16,7 @@ import { OrganisationPermissionsService } from './organisation-permissions.servi
 
 @ApiBearerAuth()
 @ApiTags('Organisation Permissions')
-@Controller('organizations')
+@Controller('organisations')
 export class OrganisationPermissionsController {
   constructor(private readonly permissionService: OrganisationPermissionsService) {}
 

--- a/src/modules/organisation-permissions/organisation-permissions.service.ts
+++ b/src/modules/organisation-permissions/organisation-permissions.service.ts
@@ -1,10 +1,10 @@
 import { HttpStatus, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
-import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { OrganisationRole } from '../organisation-role/entities/organisation-role.entity';
-import { Permissions } from './entities/permissions.entity';
 import { Organisation } from '../organisations/entities/organisations.entity';
 import { UpdatePermissionDto } from './dto/update-permission.dto';
+import { Permissions } from './entities/permissions.entity';
 
 @Injectable()
 export class OrganisationPermissionsService {
@@ -18,23 +18,23 @@ export class OrganisationPermissionsService {
   ) {}
 
   async handleUpdatePermission(org_id: string, role_id: string, updatePermissionDto: UpdatePermissionDto) {
-    await this.validateOrganizationAndRole(org_id, role_id);
+    await this.validateorganisationAndRole(org_id, role_id);
     await this.validateAndUpdatePermissions(role_id, updatePermissionDto);
     return { message: 'Permissions successfully updated', status_code: HttpStatus.OK };
   }
 
-  private async validateOrganizationAndRole(orgId: string, roleId: string): Promise<void> {
+  private async validateorganisationAndRole(orgId: string, roleId: string): Promise<void> {
     const organisation = await this.organisationRepository.findOne({
       where: { id: orgId },
       relations: ['role'],
     });
 
     if (!organisation) {
-      throw new NotFoundException(`Organization with ID ${orgId} not found`);
+      throw new NotFoundException(`organisation with ID ${orgId} not found`);
     }
 
     if (!organisation.role.some(role => role.id === roleId)) {
-      throw new NotFoundException(`Role with ID ${roleId} not found in the specified organization`);
+      throw new NotFoundException(`Role with ID ${roleId} not found in the specified organisation`);
     }
   }
 

--- a/src/modules/organisation-permissions/tests/organisation-permissions.service.spec.ts
+++ b/src/modules/organisation-permissions/tests/organisation-permissions.service.spec.ts
@@ -1,14 +1,14 @@
+import { HttpStatus, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { OrganisationPermissionsService } from '../../organisation-permissions/organisation-permissions.service';
-import { Permissions } from '../entities/permissions.entity';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { OrganisationPermissionsService } from '../../organisation-permissions/organisation-permissions.service';
 import { OrganisationRole } from '../../organisation-role/entities/organisation-role.entity';
 import { Organisation } from '../../organisations/entities/organisations.entity';
-import { HttpStatus, NotFoundException, InternalServerErrorException } from '@nestjs/common';
+import { Permissions } from '../entities/permissions.entity';
 import { mockUpdatePermissionDto } from '../mocks/organisation-permissions.mock';
-import { mockRole } from '../mocks/role.mock';
 import { mockOrganisation } from '../mocks/organisation.mock';
+import { mockRole } from '../mocks/role.mock';
 describe('OrganisationPermissionsService', () => {
   let service: OrganisationPermissionsService;
   let permissionRepository: Repository<Permissions>;
@@ -64,20 +64,20 @@ describe('OrganisationPermissionsService', () => {
       });
     });
 
-    it('should throw NotFoundException if organization is not found', async () => {
+    it('should throw NotFoundException if organisation is not found', async () => {
       jest.spyOn(organisationRepository, 'findOne').mockResolvedValue(null);
 
       await expect(service.handleUpdatePermission('org_id', 'role_id', mockUpdatePermissionDto)).rejects.toThrow(
-        new NotFoundException(`Organization with ID org_id not found`)
+        new NotFoundException(`organisation with ID org_id not found`)
       );
     });
 
-    it('should throw NotFoundException if role is not found in the organization', async () => {
+    it('should throw NotFoundException if role is not found in the organisation', async () => {
       jest.spyOn(organisationRepository, 'findOne').mockResolvedValue({ ...mockOrganisation, role: [] });
       jest.spyOn(roleRepository, 'findOne').mockResolvedValue(null);
 
       await expect(service.handleUpdatePermission('org_id', 'role_id', mockUpdatePermissionDto)).rejects.toThrow(
-        new NotFoundException(`Role with ID role_id not found in the specified organization`)
+        new NotFoundException(`Role with ID role_id not found in the specified organisation`)
       );
     });
 

--- a/src/modules/organisation-role/organisation-role.controller.ts
+++ b/src/modules/organisation-role/organisation-role.controller.ts
@@ -1,34 +1,20 @@
-import {
-  Controller,
-  Get,
-  Post,
-  Body,
-  Patch,
-  Param,
-  Delete,
-  HttpCode,
-  HttpStatus,
-  UseGuards,
-  InternalServerErrorException,
-  NotFoundException,
-  BadRequestException,
-} from '@nestjs/common';
-import { OrganisationRoleService } from './organisation-role.service';
-import { CreateOrganisationRoleDto } from './dto/create-organisation-role.dto';
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { OwnershipGuard } from '../../guards/authorization.guard';
+import { CreateOrganisationRoleDto } from './dto/create-organisation-role.dto';
+import { OrganisationRoleService } from './organisation-role.service';
 
-@ApiTags('Organization Settings')
+@ApiTags('organisation Settings')
 @UseGuards(OwnershipGuard)
 @ApiBearerAuth()
-@Controller('organizations')
+@Controller('organisations')
 export class OrganisationRoleController {
   constructor(private readonly organisationRoleService: OrganisationRoleService) {}
 
   @Post(':id/roles')
   @HttpCode(HttpStatus.CREATED)
-  @ApiOperation({ summary: 'Create a new role in an organization' })
-  @ApiParam({ name: 'organisationId', required: true, description: 'ID of the organization' })
+  @ApiOperation({ summary: 'Create a new role in an organisation' })
+  @ApiParam({ name: 'organisationId', required: true, description: 'ID of the organisation' })
   @ApiResponse({ status: 201, description: 'The role has been successfully created.' })
   @ApiResponse({ status: 400, description: 'Bad Request.' })
   @ApiResponse({ status: 401, description: 'Unauthorized.' })

--- a/src/modules/organisation-role/organisation-role.service.ts
+++ b/src/modules/organisation-role/organisation-role.service.ts
@@ -5,13 +5,13 @@ import {
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common';
-import { CreateOrganisationRoleDto } from './dto/create-organisation-role.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { OrganisationRole } from './entities/organisation-role.entity';
-import { Organisation } from '../organisations/entities/organisations.entity';
-import { Permissions } from '../organisation-permissions/entities/permissions.entity';
 import { DefaultPermissions } from '../organisation-permissions/entities/default-permissions.entity';
+import { Permissions } from '../organisation-permissions/entities/permissions.entity';
+import { Organisation } from '../organisations/entities/organisations.entity';
+import { CreateOrganisationRoleDto } from './dto/create-organisation-role.dto';
+import { OrganisationRole } from './entities/organisation-role.entity';
 
 @Injectable()
 export class OrganisationRoleService {
@@ -44,7 +44,7 @@ export class OrganisationRoleService {
         throw new ConflictException({
           status_code: HttpStatus.CONFLICT,
           error: 'Conflict',
-          message: 'A role with this name already exists in the organization',
+          message: 'A role with this name already exists in the organisation',
         });
       }
 
@@ -75,7 +75,7 @@ export class OrganisationRoleService {
       throw new InternalServerErrorException({
         status_code: HttpStatus.INTERNAL_SERVER_ERROR,
         error: 'Internal Server Error',
-        message: 'Failed to create organization role',
+        message: 'Failed to create organisation role',
       });
     }
   }

--- a/src/modules/organisation-role/tests/organisation-role.service.spec.ts
+++ b/src/modules/organisation-role/tests/organisation-role.service.spec.ts
@@ -1,12 +1,12 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { OrganisationRoleService } from '../organisation-role.service';
-import { getRepositoryToken } from '@nestjs/typeorm';
-import { OrganisationRole } from '../entities/organisation-role.entity';
-import { Organisation } from '../../organisations/entities/organisations.entity';
-import { Permissions } from '../../organisation-permissions/entities/permissions.entity';
-import { DefaultPermissions } from '../../organisation-permissions/entities/default-permissions.entity';
-import { Repository } from 'typeorm';
 import { ConflictException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DefaultPermissions } from '../../organisation-permissions/entities/default-permissions.entity';
+import { Permissions } from '../../organisation-permissions/entities/permissions.entity';
+import { Organisation } from '../../organisations/entities/organisations.entity';
+import { OrganisationRole } from '../entities/organisation-role.entity';
+import { OrganisationRoleService } from '../organisation-role.service';
 
 describe('OrganisationRoleService', () => {
   let service: OrganisationRoleService;
@@ -89,7 +89,7 @@ describe('OrganisationRoleService', () => {
   });
 
   describe('getAllRolesInOrganisation', () => {
-    it('should return an array of roles for an existing organization', async () => {
+    it('should return an array of roles for an existing organisation', async () => {
       const organisationId = '1';
       const mockRoles = [
         { id: '1', name: 'Admin', description: 'Administrator role' },

--- a/src/modules/organisations/dto/update-organisation.dto.ts
+++ b/src/modules/organisations/dto/update-organisation.dto.ts
@@ -1,6 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean, IsEmail, IsOptional, IsString, MinLength } from 'class-validator';
 import { User } from '../../user/entities/user.entity';
-import { ApiProperty, PartialType } from '@nestjs/swagger';
 
 export class UpdateOrganisationDto {
   @ApiProperty({
@@ -8,7 +8,7 @@ export class UpdateOrganisationDto {
     description: 'Name of organisation',
   })
   @IsString()
-  @MinLength(2, { message: 'Organization name must be at least 2 characters long' })
+  @MinLength(2, { message: 'organisation name must be at least 2 characters long' })
   @IsOptional()
   name?: string;
 

--- a/src/modules/organisations/organisations.controller.ts
+++ b/src/modules/organisations/organisations.controller.ts
@@ -10,20 +10,19 @@ import {
   Post,
   Query,
   Req,
-  Request,
   Res,
   UseGuards,
 } from '@nestjs/common';
-import { OrganisationsService } from './organisations.service';
-import { OrganisationRequestDto } from './dto/organisation.dto';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { UpdateOrganisationDto } from './dto/update-organisation.dto';
 import { OwnershipGuard } from '../../guards/authorization.guard';
 import { OrganisationMembersResponseDto } from './dto/org-members-response.dto';
+import { OrganisationRequestDto } from './dto/organisation.dto';
+import { UpdateOrganisationDto } from './dto/update-organisation.dto';
+import { OrganisationsService } from './organisations.service';
 
 @ApiBearerAuth()
-@ApiTags('Organization')
-@Controller('organizations')
+@ApiTags('organisation')
+@Controller('organisations')
 export class OrganisationsController {
   constructor(private readonly organisationsService: OrganisationsService) {}
 
@@ -45,7 +44,7 @@ export class OrganisationsController {
   @Delete(':org_id')
   async delete(@Param('org_id') id: string, @Res() response: Response) {
     this.organisationsService;
-    return this.organisationsService.deleteOrganization(id);
+    return this.organisationsService.deleteorganisation(id);
   }
 
   @ApiOperation({ summary: 'Update Organisation' })

--- a/src/modules/organisations/organisations.controller.ts
+++ b/src/modules/organisations/organisations.controller.ts
@@ -21,8 +21,8 @@ import { UpdateOrganisationDto } from './dto/update-organisation.dto';
 import { OrganisationsService } from './organisations.service';
 
 @ApiBearerAuth()
-@ApiTags('organisation')
-@Controller('organisations')
+@ApiTags('organization')
+@Controller('organizations')
 export class OrganisationsController {
   constructor(private readonly organisationsService: OrganisationsService) {}
 

--- a/src/modules/organisations/organisations.service.ts
+++ b/src/modules/organisations/organisations.service.ts
@@ -2,26 +2,22 @@ import {
   BadRequestException,
   ConflictException,
   ForbiddenException,
-  HttpCode,
   HttpStatus,
-  Inject,
   Injectable,
   InternalServerErrorException,
   NotFoundException,
-  UnauthorizedException,
-  UnprocessableEntityException,
 } from '@nestjs/common';
-import { Repository } from 'typeorm';
-import { Organisation } from './entities/organisations.entity';
-import { OrganisationRequestDto } from './dto/organisation.dto';
 import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { User } from '../user/entities/user.entity';
-import { OrganisationMapper } from './mapper/organisation.mapper';
-import { CreateOrganisationMapper } from './mapper/create-organisation.mapper';
-import { UpdateOrganisationDto } from './dto/update-organisation.dto';
 import { OrganisationMembersResponseDto } from './dto/org-members-response.dto';
-import { OrganisationMemberMapper } from './mapper/org-members.mapper';
+import { OrganisationRequestDto } from './dto/organisation.dto';
+import { UpdateOrganisationDto } from './dto/update-organisation.dto';
 import { OrganisationMember } from './entities/org-members.entity';
+import { Organisation } from './entities/organisations.entity';
+import { CreateOrganisationMapper } from './mapper/create-organisation.mapper';
+import { OrganisationMemberMapper } from './mapper/org-members.mapper';
+import { OrganisationMapper } from './mapper/organisation.mapper';
 
 @Injectable()
 export class OrganisationsService {
@@ -53,7 +49,7 @@ export class OrganisationsService {
     });
 
     const isMember = data.find(member => member.id === sub);
-    if (!isMember) throw new ForbiddenException('User does not have access to the organization');
+    if (!isMember) throw new ForbiddenException('User does not have access to the organisation');
 
     data = data.splice(skip, skip + page_size);
 
@@ -91,7 +87,7 @@ export class OrganisationsService {
     return { status: 'success', message: 'organisation created successfully', data: mappedResponse };
   }
 
-  async deleteOrganization(id: string) {
+  async deleteorganisation(id: string) {
     try {
       const org = await this.organisationRepository.findOneBy({ id });
       if (!org) {
@@ -119,7 +115,7 @@ export class OrganisationsService {
     try {
       const org = await this.organisationRepository.findOneBy({ id });
       if (!org) {
-        throw new NotFoundException('Organization not found');
+        throw new NotFoundException('organisation not found');
       }
       await this.organisationRepository.update(id, updateOrganisationDto);
       const updatedOrg = await this.organisationRepository.findOneBy({ id });

--- a/src/modules/products/products.controller.ts
+++ b/src/modules/products/products.controller.ts
@@ -1,19 +1,19 @@
-import { ProductsService } from './products.service';
+import { Body, Controller, Delete, HttpCode, Param, Patch, Post, UseGuards } from '@nestjs/common';
 import { ApiBody, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { UpdateProductDTO } from './dto/update-product.dto';
-import { Body, Controller, Delete, Get, HttpCode, Param, Patch, Post, UseGuards } from '@nestjs/common';
 import { OwnershipGuard } from '../../guards/authorization.guard';
 import { CreateProductRequestDto } from './dto/create-product.dto';
+import { UpdateProductDTO } from './dto/update-product.dto';
+import { ProductsService } from './products.service';
 
 @ApiTags('Products')
-@Controller('/organizations/:id/products')
+@Controller('/organisations/:id/products')
 export class ProductsController {
   constructor(private readonly productsService: ProductsService) {}
 
   @UseGuards(OwnershipGuard)
   @Post('')
   @ApiOperation({ summary: 'Creates a new product' })
-  @ApiParam({ name: 'id', description: 'Organization ID', example: '12345' })
+  @ApiParam({ name: 'id', description: 'organisation ID', example: '12345' })
   @ApiBody({ type: CreateProductRequestDto, description: 'Details of the product to be created' })
   @ApiResponse({ status: 201, description: 'Product created successfully' })
   @ApiResponse({ status: 400, description: 'Bad request' })

--- a/src/modules/user/tests/user.service.spec.ts
+++ b/src/modules/user/tests/user.service.spec.ts
@@ -1,16 +1,16 @@
+import { BadRequestException, ForbiddenException, HttpException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import UserService from '../user.service';
-import { User, UserType } from '../entities/user.entity';
-import CreateNewUserOptions from '../options/CreateNewUserOptions';
-import UserResponseDTO from '../dto/user-response.dto';
-import UserIdentifierOptionsType from '../options/UserIdentifierOptions';
-import { BadRequestException, HttpException, ForbiddenException, NotFoundException } from '@nestjs/common';
-import { UpdateUserDto } from '../dto/update-user-dto';
-import { UserPayload } from '../interfaces/user-payload.interface';
-import { DeactivateAccountDto } from '../dto/deactivate-account.dto';
 import { Profile } from '../../profile/entities/profile.entity';
+import { DeactivateAccountDto } from '../dto/deactivate-account.dto';
+import { UpdateUserDto } from '../dto/update-user-dto';
+import UserResponseDTO from '../dto/user-response.dto';
+import { User, UserType } from '../entities/user.entity';
+import { UserPayload } from '../interfaces/user-payload.interface';
+import CreateNewUserOptions from '../options/CreateNewUserOptions';
+import UserIdentifierOptionsType from '../options/UserIdentifierOptions';
+import UserService from '../user.service';
 
 describe('UserService', () => {
   let service: UserService;
@@ -81,7 +81,7 @@ describe('UserService', () => {
       expect(result).toEqual(userResponseDto);
       expect(repository.findOne).toHaveBeenCalledWith({
         where: { email },
-        relations: ['profile', 'organizationMembers', 'created_organisations', 'owned_organizations'],
+        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
       });
     });
 
@@ -100,7 +100,7 @@ describe('UserService', () => {
       expect(result).toEqual(userResponseDto);
       expect(repository.findOne).toHaveBeenCalledWith({
         where: { id },
-        relations: ['profile', 'organizationMembers', 'created_organisations', 'owned_organizations'],
+        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
       });
     });
 
@@ -166,7 +166,7 @@ describe('UserService', () => {
       });
       expect(mockUserRepository.findOne).toHaveBeenCalledWith({
         where: { id: userId },
-        relations: ['profile', 'organizationMembers', 'created_organisations', 'owned_organizations'],
+        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
       });
       expect(mockUserRepository.save).toHaveBeenCalledWith(updatedUser);
     });
@@ -188,7 +188,7 @@ describe('UserService', () => {
       });
       expect(mockUserRepository.findOne).toHaveBeenCalledWith({
         where: { id: userId },
-        relations: ['profile', 'organizationMembers', 'created_organisations', 'owned_organizations'],
+        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
       });
       expect(mockUserRepository.save).toHaveBeenCalledWith(updatedUser);
     });
@@ -199,7 +199,7 @@ describe('UserService', () => {
       await expect(service.updateUser(userId, updateOptions, anotherUserPayload)).rejects.toThrow(ForbiddenException);
       expect(mockUserRepository.findOne).toHaveBeenCalledWith({
         where: { id: userId },
-        relations: ['profile', 'organizationMembers', 'created_organisations', 'owned_organizations'],
+        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
       });
       expect(mockUserRepository.save).not.toHaveBeenCalled();
     });
@@ -213,7 +213,7 @@ describe('UserService', () => {
       );
       expect(mockUserRepository.findOne).toHaveBeenCalledWith({
         where: { id: invalidUserId },
-        relations: ['profile', 'organizationMembers', 'created_organisations', 'owned_organizations'],
+        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
       });
     });
 
@@ -235,7 +235,7 @@ describe('UserService', () => {
       );
       expect(mockUserRepository.findOne).toHaveBeenCalledWith({
         where: { id: userId },
-        relations: ['profile', 'organizationMembers', 'created_organisations', 'owned_organizations'],
+        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
       });
       expect(mockUserRepository.save).toHaveBeenCalled();
     });
@@ -267,7 +267,7 @@ describe('UserService', () => {
       expect(result.message).toBe('Account Deactivated Successfully');
       expect(mockUserRepository.findOne).toHaveBeenCalledWith({
         where: { id: userId },
-        relations: ['profile', 'organizationMembers', 'created_organisations', 'owned_organizations'],
+        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
       });
       expect(mockUserRepository.save).toHaveBeenCalledWith({ ...userToUpdate, is_active: false });
     });
@@ -288,7 +288,7 @@ describe('UserService', () => {
       });
       expect(mockUserRepository.findOne).toHaveBeenCalledWith({
         where: { id: userId },
-        relations: ['profile', 'organizationMembers', 'created_organisations', 'owned_organizations'],
+        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
       });
       expect(mockUserRepository.save).not.toHaveBeenCalled();
     });
@@ -313,7 +313,7 @@ describe('UserService', () => {
       expect(result.user).not.toHaveProperty('password');
       expect(mockUserRepository.findOne).toHaveBeenCalledWith({
         where: { id: userId },
-        relations: ['profile', 'organizationMembers', 'created_organisations', 'owned_organizations'],
+        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
       });
     });
   });

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -1,25 +1,23 @@
-import { Repository } from 'typeorm';
-import { User, UserType } from './entities/user.entity';
 import {
-  Injectable,
   BadRequestException,
-  HttpException,
-  NotFoundException,
   ForbiddenException,
+  HttpException,
   HttpStatus,
+  Injectable,
+  NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import CreateNewUserOptions from './options/CreateNewUserOptions';
-import UserIdentifierOptionsType from './options/UserIdentifierOptions';
-import UserResponseDTO from './dto/user-response.dto';
-import { ERROR_OCCURED } from '../../helpers/SystemMessages';
-import UserInterface from './interfaces/UserInterface';
-import UpdateUserRecordOption from './options/UpdateUserRecordOption';
+import { Repository } from 'typeorm';
+import { Profile } from '../profile/entities/profile.entity';
+import { DeactivateAccountDto } from './dto/deactivate-account.dto';
 import { UpdateUserDto } from './dto/update-user-dto';
 import UpdateUserResponseDTO from './dto/update-user-response.dto';
+import UserResponseDTO from './dto/user-response.dto';
+import { User, UserType } from './entities/user.entity';
 import { UserPayload } from './interfaces/user-payload.interface';
-import { DeactivateAccountDto } from './dto/deactivate-account.dto';
-import { Profile } from '../profile/entities/profile.entity';
+import CreateNewUserOptions from './options/CreateNewUserOptions';
+import UpdateUserRecordOption from './options/UpdateUserRecordOption';
+import UserIdentifierOptionsType from './options/UserIdentifierOptions';
 
 @Injectable()
 export default class UserService {
@@ -78,7 +76,7 @@ export default class UserService {
   private async getUserByEmail(email: string) {
     const user: UserResponseDTO = await this.userRepository.findOne({
       where: { email: email },
-      relations: ['profile', 'organizationMembers', 'created_organisations', 'owned_organizations'],
+      relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
     });
     return user;
   }
@@ -86,7 +84,7 @@ export default class UserService {
   private async getUserById(identifier: string) {
     const user: UserResponseDTO = await this.userRepository.findOne({
       where: { id: identifier },
-      relations: ['profile', 'organizationMembers', 'created_organisations', 'owned_organizations'],
+      relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
     });
     return user;
   }


### PR DESCRIPTION
This pull request fixes a spelling inconsistency in the codebase. The word 'Organizations' has been changed to 'Organisations' to maintain consistency throughout the codebase.

### How to test

- Create a new user

- Login with the new user account.

- Successful login

![image](https://github.com/user-attachments/assets/8679344c-0563-45f9-ae51-b5613edeee12)

#### Changes Made

- Replace all occurence of 'Organizations' with 'Organisations'