### PR TITLE
feat: get product by id

### DIFF
--- a/src/modules/products/products.controller.ts
+++ b/src/modules/products/products.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, HttpCode, Param, Patch, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, Param, Patch, Post, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { OwnershipGuard } from '../../guards/authorization.guard';
 import { CreateProductRequestDto } from './dto/create-product.dto';
@@ -21,6 +21,19 @@ export class ProductsController {
   @ApiResponse({ status: 500, description: 'Internal server error' })
   async createProduct(@Param('id') id: string, @Body() createProductDto: CreateProductRequestDto) {
     return this.productsService.createProduct(id, createProductDto);
+  }
+
+  @UseGuards(OwnershipGuard)
+  @Get(':id')
+  @ApiOperation({ summary: 'Gets a product by id' })
+  @ApiParam({ name: 'id', description: 'Organization ID', example: '12345' })
+  @ApiBody({ type: CreateProductRequestDto, description: 'Details of the product to be created' })
+  @ApiResponse({ status: 200, description: 'Product created successfully' })
+  @ApiResponse({ status: 400, description: 'Bad request' })
+  @ApiResponse({ status: 404, description: 'Product not found' })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  async getById(@Param('orgId') id: string, @Param('id') productId: string) {
+    return this.productsService.getProductById(productId);
   }
 
   @UseGuards(OwnershipGuard)

--- a/src/modules/products/products.service.ts
+++ b/src/modules/products/products.service.ts
@@ -99,6 +99,24 @@ export class ProductsService {
     }
   }
 
+  async getProductById(productId: string) {
+    try {
+      const product = await this.productRepository.findOne({ where: { id: productId } });
+      if (!product) {
+        throw new NotFoundException(`Product ${productId} not found`);
+      }
+      return {
+        message: 'Product retrieved successfully',
+        data: product,
+      };
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      throw new InternalServerErrorException(`Internal error occurred: ${error.message}`);
+    }
+  }
+
   async deleteProduct(orgId: string, productId: string) {
     const org = await this.organisationRepository.findOne({ where: { id: orgId } });
     if (!org) {


### PR DESCRIPTION
### What does this PR do
This PR is to get a product by id

## How should this be manually tested?
Send  `GET` request to `/api/v1/organizations/{:org-id}/products/{:product-id}`

- **Response:**
  **On successful retrieval:**
  ```json
  {
    "status": "success",
    "message": "Product details retrieved successfully",
    "status_code": 200,
    "data": {
      "id": 1,
      "name": "string",
      "price": 45.0
      "description": "string",
    }
  }
  ```

  **On error (e.g., product not found):**
  ```json
  {
    "status": "error",
    "message": "Product not found",
    "status_code": 404
  }
  ```

  **On error (e.g., unauthorized access):**
  ```json
  {
    "status": "error",
    "message": "Unauthorized access",
    "status_code": 401
  }
  ```

## Checklist of what you did:

- [x]  Implement the GET endpoint to retrieve product details.
- [x]  Validate inputs and handle errors appropriately.
- [x]  Write unit tests for the endpoint to ensure it handles valid and invalid inputs correctly.
- [x] Implement OrganizationGuard
- [x] Authentication and Authorization of logged in users
- [x] Write unit tests for the endpoint

## Reference Issues
[[FEAT] API Endpoint to Fetch All Roles within an Organisation](https://github.com/hngprojects/hng_boilerplate_nestjs/issues/152)