### PR TITLE
feat: remove role within an organization

### DIFF
--- a/src/modules/organisation-role/organisation-role.controller.ts
+++ b/src/modules/organisation-role/organisation-role.controller.ts
@@ -75,4 +75,40 @@ export class OrganisationRoleController {
       throw new BadRequestException('Failed to fetch role');
     }
   }
+
+  @Delete(':id/:roleId')
+  @UseGuards(AuthGuard, OwnershipGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Delete a role in an organisation' })
+  @ApiParam({ name: 'organisationId', required: true, description: 'ID of the organisation' })
+  @ApiResponse({ status: 200, description: 'Role successfully removed' })
+  @ApiResponse({ status: 400, description: 'Invalid role ID format' })
+  @ApiResponse({ status: 404, description: 'Role not found' })
+  async remove(@Param('id') organisationId: string, @Param('roleId') roleId: string, @Req() req) {
+    const currentUser = req.user;
+
+    try {
+      return await this.organisationRoleService.deleteRole(organisationId, roleId, currentUser);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw new HttpException({ status_code: 404, error: 'Not Found', message: error.message }, HttpStatus.NOT_FOUND);
+      }
+      if (error instanceof BadRequestException) {
+        throw new HttpException(
+          { status_code: 400, error: 'Bad Request', message: error.message },
+          HttpStatus.BAD_REQUEST
+        );
+      }
+      if (error instanceof UnauthorizedException) {
+        throw new HttpException(
+          { status_code: 401, error: 'Unauthorized', message: error.message },
+          HttpStatus.UNAUTHORIZED
+        );
+      }
+      throw new HttpException(
+        { status_code: 500, error: 'Internal Server Error', message: 'An unexpected error occurred' },
+        HttpStatus.INTERNAL_SERVER_ERROR
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Description:
This PR introduces a new endpoint to retrieve all roles in an organization.

## How should this be manually tested?
Send  `DELETE` request to `/api/v1/roles/{org_id}/{role-id}`

## Checklist of what you did:

- [x] Set up an endpoint for removing a single role
- [x] Implement OrganizationGuard
- [x] Authentication and Authorization of `roles/{org_id}/{role-id} DELETE` endpoint 
- [x] Validate role ID format
- [x] Implement database query to check if the role is assigned to any organization
- [x] Implement soft delete operation for roles
- [x] Implement error handling for various scenarios (invalid ID, non-existent role, non-existent organization, role in use) 
- [x] Write unit tests for the role deletion endpoint
- [x] Test error scenarios (invalid ID, non-existent role, non-existent organization, role in use)
- [x] Ensure that only users with appropriate permissions can delete roles

## Reference Issues
[[FEAT] API Endpoint to Fetch All Roles within an Organisation](https://github.com/hngprojects/hng_boilerplate_nestjs/issues/256)