### PR TITLE
feat: create waitlist page by super admin

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -38,6 +38,7 @@ import { WaitlistModule } from './modules/waitlist/waitlist.module';
 import { HelpCenterModule } from './modules/help-center/help-center.module';
 import { OrganisationRoleModule } from './modules/organisation-role/organisation-role.module';
 import { FaqModule } from './modules/faq/faq.module';
+import { WaitlistPageModule } from './modules/waitlist-pages/waitlist/waitlist-pages.module';
 
 @Module({
   providers: [
@@ -102,6 +103,7 @@ import { FaqModule } from './modules/faq/faq.module';
     HelpCenterModule,
     NotificationsModule,
     WaitlistModule,
+    WaitlistPageModule,
   ],
   controllers: [HealthController, ProbeController],
 })

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -38,7 +38,7 @@ import { WaitlistModule } from './modules/waitlist/waitlist.module';
 import { HelpCenterModule } from './modules/help-center/help-center.module';
 import { OrganisationRoleModule } from './modules/organisation-role/organisation-role.module';
 import { FaqModule } from './modules/faq/faq.module';
-import { WaitlistPageModule } from './modules/waitlist-pages/waitlist/waitlist-pages.module';
+import { WaitlistPageModule } from './modules/waitlist-pages/waitlist-pages.module';
 
 @Module({
   providers: [

--- a/src/guards/super-admin.guard.ts
+++ b/src/guards/super-admin.guard.ts
@@ -5,7 +5,7 @@ import { Repository } from 'typeorm';
 import { FORBIDDEN_ACTION } from '../helpers/SystemMessages';
 
 @Injectable()
-export class AuthGuard implements CanActivate {
+export class SuperAdminGuard implements CanActivate {
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -10,6 +10,6 @@ import { Profile } from '../profile/entities/profile.entity';
   controllers: [UserController],
   providers: [UserService, Repository],
   imports: [TypeOrmModule.forFeature([User, Profile])],
-  exports: [UserService],
+  exports: [UserService, TypeOrmModule],
 })
 export class UserModule {}

--- a/src/modules/waitlist-pages/dto/create-waitlist-page-response.dto.ts
+++ b/src/modules/waitlist-pages/dto/create-waitlist-page-response.dto.ts
@@ -1,0 +1,10 @@
+import { WaitlistPage } from '../entities/waitlist-page.entity';
+
+export class CreateWaitlistPageResponseDTO {
+  status: string;
+  status_code: number;
+  message: string;
+  data: {
+    waitlist: WaitlistPage;
+  };
+}

--- a/src/modules/waitlist-pages/dto/create-waitlist-page.dto.ts
+++ b/src/modules/waitlist-pages/dto/create-waitlist-page.dto.ts
@@ -1,0 +1,34 @@
+import { IsBoolean, IsString, IsOptional } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateWaitlistPageDTO {
+  @ApiProperty({ type: String })
+  @IsString()
+  page_title: string;
+
+  @ApiProperty({ type: String })
+  @IsString()
+  url_slug: string;
+
+  @ApiProperty({ type: String })
+  @IsString()
+  headline_text: string;
+
+  @ApiProperty({ type: String })
+  @IsString()
+  sub_headline_text: string;
+
+  @ApiProperty({ type: String })
+  @IsString()
+  body_text: string;
+
+  @ApiProperty({ type: String })
+  @IsOptional()
+  @IsString()
+  image_url: string;
+
+  @ApiProperty({ type: Boolean })
+  @IsOptional()
+  @IsBoolean()
+  status: boolean;
+}

--- a/src/modules/waitlist-pages/dto/get-waitlist-page.dto.ts
+++ b/src/modules/waitlist-pages/dto/get-waitlist-page.dto.ts
@@ -1,0 +1,10 @@
+import { WaitlistPage } from '../entities/waitlist-page.entity';
+
+export class GetWaitlistPageResponseDTO {
+  status: number;
+  status_code: number;
+  message: string;
+  data: {
+    waitlist: WaitlistPage[];
+  };
+}

--- a/src/modules/waitlist-pages/entities/waitlist-page.entity.ts
+++ b/src/modules/waitlist-pages/entities/waitlist-page.entity.ts
@@ -1,0 +1,26 @@
+import { AbstractBaseEntity } from '../../../entities/base.entity';
+import { Column, Entity } from 'typeorm';
+
+@Entity({ name: 'waitlist-page' })
+export class WaitlistPage extends AbstractBaseEntity {
+  @Column({ nullable: false })
+  page_title: string;
+
+  @Column({ nullable: false })
+  url_slug: string;
+
+  @Column({ nullable: false })
+  headline_text: string;
+
+  @Column({ nullable: false })
+  sub_headline_text: string;
+
+  @Column({ nullable: true, type: 'text' })
+  body_text: string;
+
+  @Column({ nullable: true })
+  image_url: string;
+
+  @Column({ nullable: true, default: false })
+  status: boolean;
+}

--- a/src/modules/waitlist-pages/tests/waitlist.service.spec.ts
+++ b/src/modules/waitlist-pages/tests/waitlist.service.spec.ts
@@ -1,0 +1,132 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { HttpStatus, InternalServerErrorException } from '@nestjs/common';
+import WaitlistPageService from '../waitlist-pages.service';
+import { WaitlistPage } from '../entities/waitlist-page.entity';
+import { CreateWaitlistPageDTO } from '../dto/create-waitlist-page.dto';
+
+describe('WaitlistPageService', () => {
+  let service: WaitlistPageService;
+  let repository: Repository<WaitlistPage>;
+
+  const mockRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findAndCount: jest.fn(),
+    find: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WaitlistPageService,
+        {
+          provide: getRepositoryToken(WaitlistPage),
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<WaitlistPageService>(WaitlistPageService);
+    repository = module.get<Repository<WaitlistPage>>(getRepositoryToken(WaitlistPage));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('createWaitlistPage', () => {
+    it('should create a waitlist page successfully', async () => {
+      const dto: CreateWaitlistPageDTO = {
+        page_title: 'Test Page',
+        url_slug: 'test-page',
+        headline_text: 'Test Headline',
+        sub_headline_text: 'Test Subheadline',
+        body_text: 'Test Body',
+        image_url: 'http://test.com/image.jpg',
+        status: false,
+      };
+
+      const savedWaitlistPage = { ...dto, id: 1 };
+
+      mockRepository.create.mockReturnValue(dto);
+      mockRepository.save.mockResolvedValue(savedWaitlistPage);
+
+      const result = await service.createWaitlistPage(dto);
+
+      expect(result).toEqual({
+        status: 'Success',
+        status_code: HttpStatus.CREATED,
+        message: 'Waitlist page created successfully',
+        data: {
+          waitlist: savedWaitlistPage,
+        },
+      });
+
+      expect(mockRepository.create).toHaveBeenCalledWith(dto);
+      expect(mockRepository.save).toHaveBeenCalledWith(dto);
+    });
+
+    it('should throw InternalServerErrorException on error', async () => {
+      const dto: CreateWaitlistPageDTO = {
+        page_title: 'Test Page',
+        url_slug: 'test-page',
+        headline_text: 'Test Headline',
+        sub_headline_text: 'Test Subheadline',
+        body_text: 'Test Body',
+        image_url: 'http://test.com/image.jpg',
+        status: false,
+      };
+
+      mockRepository.create.mockReturnValue(dto);
+      mockRepository.save.mockRejectedValue(new Error('Database error'));
+
+      await expect(service.createWaitlistPage(dto)).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+
+  describe('getAllWaitlistPages', () => {
+    it('should return all waitlist pages with pagination', async () => {
+      const mockWaitlistPages = [
+        { id: 1, page_title: 'Page 1', url_slug: 'page-1', status: 'active', created_at: new Date() },
+        { id: 2, page_title: 'Page 2', url_slug: 'page-2', status: 'inactive', created_at: new Date() },
+      ];
+
+      mockRepository.findAndCount.mockResolvedValue([mockWaitlistPages, 2]);
+      mockRepository.find.mockResolvedValue(mockWaitlistPages);
+
+      const result = await service.getAllWaitlistPages(1, 10);
+
+      expect(result).toEqual({
+        status_code: HttpStatus.OK,
+        status: 'Success',
+        message: 'Waitlist pages retrieved successfully',
+        data: {
+          waitlistPages: mockWaitlistPages,
+        },
+      });
+
+      expect(mockRepository.findAndCount).toHaveBeenCalledWith({
+        select: ['id', 'page_title', 'url_slug', 'status', 'created_at'],
+        skip: 0,
+        take: 10,
+        order: { created_at: 'DESC' },
+      });
+    });
+
+    it('should handle pagination correctly', async () => {
+      mockRepository.findAndCount.mockResolvedValue([[], 0]);
+      mockRepository.find.mockResolvedValue([]);
+
+      await service.getAllWaitlistPages(2, 5);
+
+      expect(mockRepository.findAndCount).toHaveBeenCalledWith({
+        select: ['id', 'page_title', 'url_slug', 'status', 'created_at'],
+        skip: 5,
+        take: 5,
+        order: { created_at: 'DESC' },
+      });
+    });
+  });
+});

--- a/src/modules/waitlist-pages/waitlist-pages.controller.ts
+++ b/src/modules/waitlist-pages/waitlist-pages.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, UseGuards, Query } from '@nestjs/common';
+import WaitlistPageService from './waitlist-pages.service';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { GetWaitlistPageResponseDTO } from './dto/get-waitlist-page.dto';
+import { CreateWaitlistPageDTO } from './dto/create-waitlist-page.dto';
+import { CreateWaitlistPageResponseDTO } from './dto/create-waitlist-page-response.dto';
+import { AuthGuard } from 'src/guards/super-admin.guard';
+
+@UseGuards(AuthGuard)
+@ApiBearerAuth()
+@ApiTags('Waitlist Pages')
+@Controller('waitlist-pages')
+export class WaitlistPageController {
+  constructor(private readonly waitlistPageService: WaitlistPageService) {}
+
+  @ApiOperation({ summary: 'Create a new waitlist page' })
+  @ApiResponse({ status: 201, description: 'Waitlist page created successfully', type: CreateWaitlistPageResponseDTO })
+  @ApiResponse({ status: 400, description: 'Bad Request' })
+  @ApiResponse({ status: 500, description: 'Internal Server Error' })
+  @Post()
+  createWaitlistPage(@Body() createWaitlistPageDTO: CreateWaitlistPageDTO): Promise<CreateWaitlistPageResponseDTO> {
+    return this.waitlistPageService.createWaitlistPage(createWaitlistPageDTO);
+  }
+
+  @ApiOperation({ summary: 'Get all waitlist pages' })
+  @ApiResponse({ status: 200, description: 'Waitlist pages retrieved successfully', type: GetWaitlistPageResponseDTO })
+  @ApiResponse({ status: 500, description: 'Internal Server Error' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @Get()
+  getAllWaitlist(@Query('page') page: number = 1, @Query('limit') limit: number = 10) {
+    return this.waitlistPageService.getAllWaitlistPages(page, limit);
+  }
+}

--- a/src/modules/waitlist-pages/waitlist-pages.controller.ts
+++ b/src/modules/waitlist-pages/waitlist-pages.controller.ts
@@ -4,9 +4,9 @@ import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@ne
 import { GetWaitlistPageResponseDTO } from './dto/get-waitlist-page.dto';
 import { CreateWaitlistPageDTO } from './dto/create-waitlist-page.dto';
 import { CreateWaitlistPageResponseDTO } from './dto/create-waitlist-page-response.dto';
-import { AuthGuard } from 'src/guards/super-admin.guard';
+import { SuperAdminGuard } from 'src/guards/super-admin.guard';
 
-@UseGuards(AuthGuard)
+@UseGuards(SuperAdminGuard)
 @ApiBearerAuth()
 @ApiTags('Waitlist Pages')
 @Controller('waitlist-pages')

--- a/src/modules/waitlist-pages/waitlist-pages.module.ts
+++ b/src/modules/waitlist-pages/waitlist-pages.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { WaitlistPageController } from './waitlist-pages.controller';
+import WaitlistPageService from './waitlist-pages.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { WaitlistPage } from './entities/waitlist-page.entity';
+import { UserModule } from 'src/modules/user/user.module';
+
+@Module({
+  controllers: [WaitlistPageController],
+  providers: [WaitlistPageService],
+  imports: [TypeOrmModule.forFeature([WaitlistPage]), UserModule],
+})
+export class WaitlistPageModule {}

--- a/src/modules/waitlist-pages/waitlist-pages.service.ts
+++ b/src/modules/waitlist-pages/waitlist-pages.service.ts
@@ -1,0 +1,62 @@
+import { HttpStatus, Injectable, InternalServerErrorException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { WaitlistPage } from './entities/waitlist-page.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { CreateWaitlistPageDTO } from './dto/create-waitlist-page.dto';
+import { CreateWaitlistPageResponseDTO } from './dto/create-waitlist-page-response.dto';
+
+@Injectable()
+export default class WaitlistPageService {
+  constructor(@InjectRepository(WaitlistPage) private readonly waitlistPageRepository: Repository<WaitlistPage>) {}
+
+  async createWaitlistPage(createWaitlistPageDTO: CreateWaitlistPageDTO): Promise<CreateWaitlistPageResponseDTO> {
+    try {
+      const newWaitlistPage = this.waitlistPageRepository.create(createWaitlistPageDTO);
+      const savedWaitlistPage = await this.waitlistPageRepository.save(newWaitlistPage);
+
+      return {
+        status: 'Success',
+        status_code: HttpStatus.CREATED,
+        message: 'Waitlist page created successfully',
+        data: {
+          waitlist: savedWaitlistPage,
+        },
+      };
+    } catch (error) {
+      throw new InternalServerErrorException({ message: 'Internal Server Error' });
+    }
+  }
+
+  async getAllWaitlistPages(page: number = 1, limit: number = 10) {
+    const [waitlist_pages, total] = await this.waitlistPageRepository.findAndCount({
+      select: ['id', 'page_title', 'url_slug', 'status', 'created_at'],
+      skip: (page - 1) * limit,
+      take: limit,
+      order: { created_at: 'DESC' },
+    });
+
+    const pagination = {
+      current_page: page,
+      total_pages: Math.ceil(total / limit),
+      total_users: total,
+    };
+
+    const formattedUsers = waitlist_pages.map(waitlist_page => ({
+      id: waitlist_page.id,
+      page_title: waitlist_page.page_title,
+      url_slug: waitlist_page.url_slug,
+      status: waitlist_page.status,
+      created_at: waitlist_page.created_at,
+    }));
+
+    const waitlistPages = await this.waitlistPageRepository.find();
+    return {
+      status_code: HttpStatus.OK,
+      status: 'Success',
+      message: 'Waitlist pages retrieved successfully',
+      data: {
+        waitlistPages,
+      },
+    };
+  }
+}


### PR DESCRIPTION
### What does this PR do?
This PR is about allowing super admins to crate waitlist pages.

### How should this be manually tested?
Send a POST request to this enpdoint:

`POST /api/v1/waitlist-pages`

Request Headers:
```
{
   "Authorization": "Bearer <token>"
}

```
POST Request Body:
```
{
  "page_title": "String",
  "url_slug": "String",
  "headline_text": "String",
  "sub_headline_text": "String",
  "body_text": "String",
  "image_url": "String"
}

```
## Expected Outcome
Successful POST Response:
```
{
    "status": "Success",
    "status_code": 201,
    "message": "Waitlist page created successfully",
    "data": {
        "waitlist": {
            "id": "String",
            "page_title": "String",
            "url_slug": "String",
            "headline_text": "String",
            "sub_headline_text": "String",
            "body_text": "String",
            "image_url": "String",
            "created_at": "String (date)"
        }
    }
}


### POSTMAN TEST
![image](https://github.com/user-attachments/assets/36d63488-172f-47a7-b2af-ec569936aba8)

### Test
![test proof](https://github.com/user-attachments/assets/e4d5bf15-7474-40a2-b44c-5e586f36a0a5)


### Reference Issue
[FEAT: Create Wailist Page](https://github.com/hngprojects/hng_boilerplate_nestjs/issues/590)