### PR TITLE
feat: update role within an organisation

### DIFF
--- a/src/modules/organisation-role/organisation-role.controller.ts
+++ b/src/modules/organisation-role/organisation-role.controller.ts
@@ -90,7 +90,17 @@ export class OrganisationRoleController {
   }
 
   @Patch(':orgId/roles/:roleId')
-  async update(
+  @ApiOperation({ summary: 'update a role within an organization' })
+  @ApiResponse({
+    status: 200,
+    description: 'The role has been successfully updated',
+  })
+  @ApiResponse({ status: 400, description: 'Invalid role ID format or input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
+  @ApiResponse({ status: 403, description: 'Forbidden.' })
+  @ApiResponse({ status: 404, description: 'Role not found' })
+  @ApiResponse({ status: 404, description: 'Organisation not found' })
+  async updateRole(
     updateRoleDto: UpdateOrganisationRoleDto,
     @Param('orgId') orgId: string,
     @Param('roleId') roleId: string

--- a/src/modules/organisation-role/organisation-role.controller.ts
+++ b/src/modules/organisation-role/organisation-role.controller.ts
@@ -7,6 +7,7 @@ import {
   HttpStatus,
   NotFoundException,
   Param,
+  Patch,
   Post,
   UseGuards,
 } from '@nestjs/common';
@@ -14,6 +15,7 @@ import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@ne
 import { OwnershipGuard } from '../../guards/authorization.guard';
 import { CreateOrganisationRoleDto } from './dto/create-organisation-role.dto';
 import { OrganisationRoleService } from './organisation-role.service';
+import { UpdateOrganisationRoleDto } from './dto/update-organisation-role.dto';
 
 @ApiTags('organisation Settings')
 @UseGuards(OwnershipGuard)
@@ -85,5 +87,19 @@ export class OrganisationRoleController {
       }
       throw new BadRequestException('Failed to fetch role');
     }
+  }
+
+  @Patch(':orgId/roles/:roleId')
+  async update(
+    updateRoleDto: UpdateOrganisationRoleDto,
+    @Param('orgId') orgId: string,
+    @Param('roleId') roleId: string
+  ) {
+    const data = await this.organisationRoleService.updateRole(updateRoleDto, orgId, roleId);
+
+    return {
+      status_code: 200,
+      data,
+    };
   }
 }

--- a/src/modules/organisation-role/organisation-role.service.ts
+++ b/src/modules/organisation-role/organisation-role.service.ts
@@ -12,6 +12,7 @@ import { Permissions } from '../organisation-permissions/entities/permissions.en
 import { Organisation } from '../organisations/entities/organisations.entity';
 import { CreateOrganisationRoleDto } from './dto/create-organisation-role.dto';
 import { OrganisationRole } from './entities/organisation-role.entity';
+import { UpdateOrganisationRoleDto } from './dto/update-organisation-role.dto';
 
 @Injectable()
 export class OrganisationRoleService {
@@ -123,5 +124,41 @@ export class OrganisationRoleService {
       }
       throw new Error(`Failed to fetch role: ${error.message}`);
     }
+  }
+
+  async updateRole(updateRoleDto: UpdateOrganisationRoleDto, orgId: string, roleId: string) {
+    const organisation = await this.organisationRepository.findOne({
+      where: {
+        id: orgId,
+      },
+    });
+
+    if (!organisation) {
+      throw new NotFoundException({
+        status_code: HttpStatus.NOT_FOUND,
+        error: 'Organization not found',
+        message: `The organization with ID ${orgId} does not exist`,
+      });
+    }
+
+    const role = await this.rolesRepository.findOne({
+      where: {
+        id: roleId,
+        organisation: organisation,
+      },
+    });
+
+    if (!role) {
+      throw new NotFoundException({
+        status_code: HttpStatus.NOT_FOUND,
+        error: 'Role not found',
+        message: `The role with ID ${roleId} does not exist`,
+      });
+    }
+
+    Object.assign(role, updateRoleDto);
+
+    await this.rolesRepository.save(role);
+    return role;
   }
 }

--- a/src/modules/organisation-role/tests/organisation-role.service.spec.ts
+++ b/src/modules/organisation-role/tests/organisation-role.service.spec.ts
@@ -7,6 +7,7 @@ import { Permissions } from '../../organisation-permissions/entities/permissions
 import { Organisation } from '../../organisations/entities/organisations.entity';
 import { OrganisationRole } from '../entities/organisation-role.entity';
 import { OrganisationRoleService } from '../organisation-role.service';
+import { UpdateOrganisationRoleDto } from '../dto/update-organisation-role.dto';
 
 describe('OrganisationRoleService', () => {
   let service: OrganisationRoleService;
@@ -153,6 +154,57 @@ describe('OrganisationRoleService', () => {
       jest.spyOn(rolesRepository, 'findOne').mockResolvedValue(null);
 
       await expect(service.findSingleRole('nonexistent', 'org123')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('updateRole', () => {
+    it('should update the role successfully', async () => {
+      const updateRoleDto: UpdateOrganisationRoleDto = { name: 'Updated Role', description: 'Updated Description' };
+      const orgId = 'org-id';
+      const roleId = 'role-id';
+
+      const organisation = new Organisation();
+      organisation.id = orgId;
+
+      const role = new OrganisationRole();
+      role.id = roleId;
+      role.name = 'Original Role';
+      role.description = 'Original Description';
+      role.organisation = organisation;
+
+      jest.spyOn(organisationRepository, 'findOne').mockResolvedValue(organisation);
+      jest.spyOn(rolesRepository, 'findOne').mockResolvedValue(role);
+      jest.spyOn(rolesRepository, 'save').mockResolvedValue(role);
+
+      const result = await service.updateRole(updateRoleDto, orgId, roleId);
+
+      expect(result.name).toBe('Updated Role');
+      expect(result.description).toBe('Updated Description');
+      expect(rolesRepository.save).toHaveBeenCalledWith(expect.objectContaining(updateRoleDto));
+    });
+
+    it('should throw NotFoundException if the organisation does not exist', async () => {
+      const updateRoleDto: UpdateOrganisationRoleDto = { name: 'Starlight Role', description: 'Updated Description' };
+      const orgId = 'non-existent-org-id';
+      const roleId = 'role-id';
+
+      jest.spyOn(organisationRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(service.updateRole(updateRoleDto, orgId, roleId)).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw NotFoundException if the role does not exist', async () => {
+      const updateRoleDto: UpdateOrganisationRoleDto = { name: 'Starlight Mentor', description: 'Updated Description' };
+      const orgId = 'org-id';
+      const roleId = 'non-existent-role-id';
+
+      const organisation = new Organisation();
+      organisation.id = orgId;
+
+      jest.spyOn(organisationRepository, 'findOne').mockResolvedValue(organisation);
+      jest.spyOn(rolesRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(service.updateRole(updateRoleDto, orgId, roleId)).rejects.toThrow(NotFoundException);
     });
   });
 });


### PR DESCRIPTION
## What does this PR do?

This PR introduces an endpoint for updating a role within an organization.

## How it can be tested
Make a `PATCH` request to the endpoint `/api/v1/organisations/{org_id}/roles/{role_id}` with a request body matching this:

```jsonc
{
 "name": "updated role", // the role name
 "description": "updated description" // a description of the role
}
```

### Success Response (200 OK)

```json
{
  "status_code": 200,
  "data": {
    "id": "string",
    "name": "string",
    "description": "string"
  }
}

```

### Error Responses

**400 Bad Request:**

```json
{
  "status_code": 400,
  "error": "Bad Request",
  "message": "Invalid role ID format or input data"
}
```

**404 Not Found (Role):**

```json
{
  "status_code": 404,
  "error": "Role not found",
  "message": "The role with ID ${id} does not exist"
}
```

**404 Not Found (Organization):**

```json
{
  "status_code": 404,
  "error": "Organisation not found",
  "message": "The organisation with ID ${id} does not exist"
}
```

## Checklist of What I Did

- [x] Set up an endpoint for updating a single role
- [x] Implement OrganizationGuard
- [x] Authentication and Authorization of organisation/roles/{role-id} PATCH endpoint
- [x] Validate role ID format and input data
- [x] Implement database query to update role information
- [x] Implement error handling for various scenarios (invalid ID, non-existent role, non-existent organization,)
- [x] Write unit tests for the role update service


## Reference Issue
#153: Update A Role within an Organization | 153
Linear issue link: https://linear.app/team-bingo/issue/BAC2-19/update-a-role-within-an-organization-or-153