### PR TITLE
feat: super admin squeeze pages crud operations

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -38,6 +38,7 @@ import { WaitlistModule } from './modules/waitlist/waitlist.module';
 import { HelpCenterModule } from './modules/help-center/help-center.module';
 import { OrganisationRoleModule } from './modules/organisation-role/organisation-role.module';
 import { FaqModule } from './modules/faq/faq.module';
+import { SqueezePagesModule } from './modules/squeeze-pages/squeeze-pages.module';
 
 @Module({
   providers: [
@@ -103,6 +104,7 @@ import { FaqModule } from './modules/faq/faq.module';
     HelpCenterModule,
     NotificationsModule,
     WaitlistModule,
+    SqueezePagesModule,
   ],
   controllers: [HealthController, ProbeController],
 })

--- a/src/modules/squeeze-pages/dto/create-squeeze-pages-response.dto.ts
+++ b/src/modules/squeeze-pages/dto/create-squeeze-pages-response.dto.ts
@@ -1,0 +1,43 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SqueezePage } from '../entities/squeeze-pages.entity';
+
+export class CreateSqueezePageResponseDto {
+  @ApiProperty({
+    example: 'success',
+    description: 'The status of the response',
+    nullable: false,
+  })
+  status: string;
+
+  @ApiProperty({
+    example: 201,
+    description: 'The status code of the response',
+    nullable: false,
+  })
+  status_code: number;
+
+  @ApiProperty({
+    example: 'Squeeze page created successfully',
+    description: 'The message of the response',
+    nullable: false,
+  })
+  message: string;
+
+  @ApiProperty({
+    example: {
+      id: 1,
+      title: 'My Squeeze Page',
+      uri_slug: 'my-squeeze-page',
+      user_id: 1,
+      created_at: '2021-10-01T00:00:00.000Z',
+      updated_at: '2021-10-01T00:00:00.000Z',
+    },
+    description: 'The data of the response',
+    nullable: false,
+  })
+  data: CreateSqueezePageResponseData;
+}
+
+type CreateSqueezePageResponseData = {
+  squeeze_page: SqueezePage;
+};

--- a/src/modules/squeeze-pages/dto/create-squeeze-pages.dto.ts
+++ b/src/modules/squeeze-pages/dto/create-squeeze-pages.dto.ts
@@ -1,0 +1,58 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class CreateSqueezePageDto {
+  @ApiProperty({
+    example: 'Product Squeeze Page',
+    description: 'The page title of the squeeze page',
+    nullable: false,
+    uniqueItems: true,
+  })
+  @IsString()
+  @IsNotEmpty()
+  page_title: string;
+
+  @ApiProperty({
+    example: 'product',
+    description: 'The URL slug of the squeeze page',
+    nullable: false,
+  })
+  @IsString()
+  @IsNotEmpty()
+  url_slug: string;
+
+  @ApiProperty({
+    example: 'Product Headline',
+    description: 'The headline of the squeeze page',
+    nullable: false,
+  })
+  @IsString()
+  @IsNotEmpty()
+  headline: string;
+
+  @ApiProperty({
+    example: 'Product Sub Headline',
+    description: 'The sub headline of the squeeze page',
+    nullable: false,
+  })
+  @IsString()
+  @IsNotEmpty()
+  sub_headline: string;
+
+  @ApiProperty({
+    example: 'Product Body',
+    description: 'The body of the squeeze page',
+    nullable: false,
+  })
+  @IsString()
+  @IsNotEmpty()
+  body: string;
+
+  @ApiProperty({
+    example: 'Product Image',
+    description: 'The image of the squeeze page',
+    nullable: true,
+  })
+  @IsOptional()
+  image: string;
+}

--- a/src/modules/squeeze-pages/dto/delete-squeeze-page-response.dto.ts
+++ b/src/modules/squeeze-pages/dto/delete-squeeze-page-response.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeleteSqueezePageResponseDto {
+  @ApiProperty({
+    example: 'success',
+    description: 'The status of the response',
+    nullable: false,
+  })
+  status: string;
+
+  @ApiProperty({
+    example: 200,
+    description: 'The status code of the response',
+    nullable: false,
+  })
+  status_code: number;
+
+  @ApiProperty({
+    example: 'Squeeze page deleted successfully',
+    description: 'The message of the response',
+    nullable: false,
+  })
+  message: string;
+}

--- a/src/modules/squeeze-pages/dto/get-squeeze-pages-response.dto.ts
+++ b/src/modules/squeeze-pages/dto/get-squeeze-pages-response.dto.ts
@@ -1,0 +1,49 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SqueezePage } from '../entities/squeeze-pages.entity';
+
+export class GetSqueezePagesResponseDto {
+  @ApiProperty({
+    example: 'success',
+    description: 'The status of the response',
+    nullable: false,
+  })
+  status: string;
+
+  @ApiProperty({
+    example: 200,
+    description: 'The status code of the response',
+    nullable: false,
+  })
+  status_code: number;
+
+  @ApiProperty({
+    example: 'Squeeze pages fetched successfully',
+    description: 'The message of the response',
+    nullable: false,
+  })
+  message: string;
+
+  @ApiProperty({
+    example: {
+      squeeze_pages: [
+        {
+          id: 1,
+          title: 'My Squeeze Page',
+          uri_slug: 'my-squeeze-page',
+          user_id: 1,
+          created_at: '2021-10-01T00:00:00.000Z',
+          updated_at: '2021-10-01T00:00:00.000Z',
+        },
+      ],
+      total: 1,
+    },
+    description: 'The data of the response',
+    nullable: true,
+  })
+  data: SqueezePagesResponseData;
+}
+
+type SqueezePagesResponseData = {
+  squeeze_pages: SqueezePage[];
+  total: number;
+};

--- a/src/modules/squeeze-pages/dto/get-squeeze-pages-url-slugs-response.dto.ts
+++ b/src/modules/squeeze-pages/dto/get-squeeze-pages-url-slugs-response.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetSqueezePagesUrlSlugsResponseDto {
+  @ApiProperty({
+    example: 'success',
+    description: 'The status of the response',
+    nullable: false,
+  })
+  status: string;
+
+  @ApiProperty({
+    example: 200,
+    description: 'The status code of the response',
+    nullable: false,
+  })
+  status_code: number;
+
+  @ApiProperty({
+    example: 'Squeeze pages URL slugs fetched successfully',
+    description: 'The message of the response',
+    nullable: false,
+  })
+  message: string;
+
+  @ApiProperty({
+    example: {
+      squeeze_pages_slug_uri: ['product', 'service'],
+    },
+    description: 'The data of the response',
+    nullable: true,
+  })
+  data: SqueezePagesUrlSlugsResponseDto;
+}
+
+type SqueezePagesUrlSlugsResponseDto = {
+  squeeze_pages_slug_uri: string[];
+};

--- a/src/modules/squeeze-pages/dto/update-squeeze-page-response.dto.ts
+++ b/src/modules/squeeze-pages/dto/update-squeeze-page-response.dto.ts
@@ -1,0 +1,43 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SqueezePage } from '../entities/squeeze-pages.entity';
+
+export class UpdateSqueezePageResponseDto {
+  @ApiProperty({
+    example: 'success',
+    description: 'The status of the response',
+    nullable: false,
+  })
+  status: string;
+
+  @ApiProperty({
+    example: 200,
+    description: 'The status code of the response',
+    nullable: false,
+  })
+  status_code: number;
+
+  @ApiProperty({
+    example: 'Squeeze page updated successfully',
+    description: 'The message of the response',
+    nullable: false,
+  })
+  message: string;
+
+  @ApiProperty({
+    example: {
+      id: 1,
+      title: 'My Squeeze Page',
+      uri_slug: 'my-squeeze-page',
+      user_id: 1,
+      created_at: '2021-10-01T00:00:00.000Z',
+      updated_at: '2021-10-01T00:00:00.000Z',
+    },
+    description: 'The data of the response',
+    nullable: false,
+  })
+  data: UpdateSqueezePageResponseData;
+}
+
+type UpdateSqueezePageResponseData = {
+  squeeze_page: SqueezePage;
+};

--- a/src/modules/squeeze-pages/dto/update-squeeze-pages.dto.ts
+++ b/src/modules/squeeze-pages/dto/update-squeeze-pages.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateSqueezePageDto } from './create-squeeze-pages.dto';
+
+export class UpdateSqueezePageDto extends PartialType(CreateSqueezePageDto) {}

--- a/src/modules/squeeze-pages/entities/squeeze-pages.entity.ts
+++ b/src/modules/squeeze-pages/entities/squeeze-pages.entity.ts
@@ -1,0 +1,26 @@
+import { AbstractBaseEntity } from '../../../entities/base.entity';
+import { Column, Entity } from 'typeorm';
+
+@Entity({ name: 'squeeze_pages' })
+export class SqueezePage extends AbstractBaseEntity {
+  @Column({ nullable: false, unique: true })
+  page_title: string;
+
+  @Column({ nullable: false })
+  url_slug: string;
+
+  @Column({ nullable: false })
+  headline: string;
+
+  @Column({ nullable: false })
+  sub_headline: string;
+
+  @Column({ nullable: false })
+  body: string;
+
+  @Column({ nullable: true })
+  image: string;
+
+  @Column({ nullable: false, default: false })
+  status: boolean;
+}

--- a/src/modules/squeeze-pages/squeeze-pages.controller.ts
+++ b/src/modules/squeeze-pages/squeeze-pages.controller.ts
@@ -1,0 +1,91 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from '@nestjs/common';
+import { SqueezePagesService } from './squeeze-pages.service';
+import { CreateSqueezePageDto } from './dto/create-squeeze-pages.dto';
+import { UpdateSqueezePageDto } from './dto/update-squeeze-pages.dto';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { GetSqueezePagesResponseDto } from './dto/get-squeeze-pages-response.dto';
+import { CreateSqueezePageResponseDto } from './dto/create-squeeze-pages-response.dto';
+import { GetSqueezePagesUrlSlugsResponseDto } from './dto/get-squeeze-pages-url-slugs-response.dto';
+import { UpdateSqueezePageResponseDto } from './dto/update-squeeze-page-response.dto';
+import { DeleteSqueezePageResponseDto } from './dto/delete-squeeze-page-response.dto';
+
+@ApiBearerAuth()
+@ApiTags('Squeeze Pages')
+@Controller('squeeze-pages')
+export class SqueezePagesController {
+  constructor(private readonly squeezePagesService: SqueezePagesService) {}
+
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a new squeeze page' })
+  @ApiResponse({
+    status: 201,
+    description: 'The squeeze page has been successfully created.',
+    type: CreateSqueezePageResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Bad Request.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
+  @ApiResponse({ status: 500, description: 'Internal' })
+  @Post()
+  create(@Body() createSqueezePagesDto: CreateSqueezePageDto) {
+    return this.squeezePagesService.create(createSqueezePagesDto);
+  }
+
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all squeeze pages or paginated or search' })
+  @ApiResponse({ status: 200, description: 'Squeeze pages fetched successfully', type: GetSqueezePagesResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 500, description: 'Internal Server Error' })
+  @Get()
+  findAll(@Query('title') title: string, @Query('page') pageNumber: number, @Query('limit') limit: number) {
+    if (title) {
+      return this.squeezePagesService.findByTitle(title);
+    }
+    if (pageNumber && limit) {
+      return this.squeezePagesService.findPaginated(pageNumber, limit);
+    }
+    return this.squeezePagesService.findAll();
+  }
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all squeeze pages url slugs' })
+  @ApiResponse({
+    status: 200,
+    description: 'Squeeze pages url slugs fetched successfully',
+    type: GetSqueezePagesUrlSlugsResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 500, description: 'Internal Server Error' })
+  @Get('/uri-slugs')
+  findByUriSlugs() {
+    return this.squeezePagesService.findUriSlugs();
+  }
+
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a squeeze page by id' })
+  @ApiResponse({
+    status: 200,
+    description: 'The squeeze page has been successfully updated.',
+    type: UpdateSqueezePageResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Bad Request.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
+  @ApiResponse({ status: 500, description: 'Internal Server Error.' })
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateSqueezePagesDto: UpdateSqueezePageDto) {
+    return this.squeezePagesService.update(id, updateSqueezePagesDto);
+  }
+
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a squeeze page by id' })
+  @ApiResponse({
+    status: 200,
+    description: 'The squeeze page has been successfully deleted.',
+    type: DeleteSqueezePageResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Bad Request.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
+  @ApiResponse({ status: 500, description: 'Internal Server Error.' })
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.squeezePagesService.remove(id);
+  }
+}

--- a/src/modules/squeeze-pages/squeeze-pages.module.ts
+++ b/src/modules/squeeze-pages/squeeze-pages.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { SqueezePagesService } from './squeeze-pages.service';
+import { SqueezePagesController } from './squeeze-pages.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SqueezePage } from './entities/squeeze-pages.entity';
+
+@Module({
+  controllers: [SqueezePagesController],
+  providers: [SqueezePagesService],
+  imports: [TypeOrmModule.forFeature([SqueezePage])],
+})
+export class SqueezePagesModule {}

--- a/src/modules/squeeze-pages/squeeze-pages.service.ts
+++ b/src/modules/squeeze-pages/squeeze-pages.service.ts
@@ -1,0 +1,125 @@
+import { ConflictException, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import { CreateSqueezePageDto } from './dto/create-squeeze-pages.dto';
+import { UpdateSqueezePageDto } from './dto/update-squeeze-pages.dto';
+import { SqueezePage } from './entities/squeeze-pages.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
+
+@Injectable()
+export class SqueezePagesService {
+  constructor(
+    @InjectRepository(SqueezePage)
+    private readonly squeezePagesRepository: Repository<SqueezePage>
+  ) {}
+
+  async create(createSqueezePagesDto: CreateSqueezePageDto) {
+    try {
+      const squeezePage = new SqueezePage();
+      Object.assign(squeezePage, createSqueezePagesDto);
+      await this.squeezePagesRepository.save(squeezePage);
+      return {
+        status: 'success',
+        status_code: 201,
+        message: 'Squeeze Page created successfully.',
+        data: {
+          squeeze_page: squeezePage,
+        },
+      };
+    } catch (error) {
+      if (error instanceof QueryFailedError) {
+        if (error.message.includes('duplicate key')) {
+          throw new ConflictException('Squeeze Page with this title already exists');
+        }
+      }
+
+      throw new InternalServerErrorException('Internal Server Error');
+    }
+  }
+
+  async findUriSlugs() {
+    const squeezePagesSlug = await this.squeezePagesRepository.find({ select: ['url_slug'] });
+
+    const squeezePagesSlugUrl = squeezePagesSlug.map(squeezePage => squeezePage.url_slug);
+    return {
+      status: 'success',
+      status_code: 200,
+      message: 'Squeeze Pages retrieved successfully.',
+      data: {
+        squeeze_pages_slug_uri: squeezePagesSlugUrl,
+      },
+    };
+  }
+
+  async findAll() {
+    const [squeezePages, total] = await this.squeezePagesRepository.findAndCount();
+    return {
+      status: 'success',
+      status_code: 200,
+      message: 'Squeeze Pages retrieved successfully.',
+      data: {
+        squeeze_pages: squeezePages,
+        total,
+      },
+    };
+  }
+
+  async findPaginated(pageNumber: number, limit: number) {
+    const skip = (pageNumber - 1) * limit;
+    const [squeezePages, total] = await this.squeezePagesRepository.findAndCount({
+      skip,
+      take: limit,
+    });
+    return {
+      status: 'success',
+      status_code: 200,
+      message: 'Squeeze Pages retrieved successfully.',
+      data: {
+        squeeze_pages: squeezePages,
+        total,
+      },
+    };
+  }
+
+  async findByTitle(title: string) {
+    const [squeezePage, total] = await this.squeezePagesRepository.findAndCount({ where: { page_title: title } });
+    return {
+      status: 'success',
+      status_code: 200,
+      message: 'Squeeze Pages retrieved successfully.',
+      data: {
+        squeeze_page: squeezePage,
+        total,
+      },
+    };
+  }
+
+  async update(id: string, updateSqueezePagesDto: UpdateSqueezePageDto) {
+    const squeezePage = await this.squeezePagesRepository.findOne({ where: { id } });
+    if (!squeezePage) {
+      throw new NotFoundException('Squeeze Page not found');
+    }
+    Object.assign(squeezePage, updateSqueezePagesDto);
+    await this.squeezePagesRepository.save(squeezePage);
+    return {
+      status: 'success',
+      status_code: 200,
+      message: 'Squeeze Page updated successfully.',
+      data: {
+        squeeze_page: squeezePage,
+      },
+    };
+  }
+
+  async remove(id: string) {
+    const squeezePage = await this.squeezePagesRepository.findOne({ where: { id } });
+    if (!squeezePage) {
+      throw new NotFoundException('Squeeze Page not found');
+    }
+    await this.squeezePagesRepository.remove(squeezePage);
+    return {
+      status: 'success',
+      status_code: 200,
+      message: 'Squeeze Page removed successfully.',
+    };
+  }
+}

--- a/src/modules/squeeze-pages/tests/squeeze-pages.service.spec.ts
+++ b/src/modules/squeeze-pages/tests/squeeze-pages.service.spec.ts
@@ -1,0 +1,304 @@
+import { Repository } from 'typeorm';
+import { SqueezePagesService } from '../squeeze-pages.service';
+import { SqueezePage } from '../entities/squeeze-pages.entity';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CreateSqueezePageDto } from '../dto/create-squeeze-pages.dto';
+import { mock } from 'node:test';
+import { UpdateSqueezePageDto } from '../dto/update-squeeze-pages.dto';
+
+describe('SqueezePaagesService', () => {
+  let squeezePagesService: SqueezePagesService;
+  let repository: Repository<SqueezePage>;
+
+  const mockSqueezePageRepository = {
+    save: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    remove: jest.fn(),
+    findAndCount: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SqueezePagesService,
+        {
+          provide: 'SqueezePageRepository',
+          useValue: mockSqueezePageRepository,
+        },
+      ],
+    }).compile();
+
+    squeezePagesService = module.get<SqueezePagesService>(SqueezePagesService);
+    repository = module.get<Repository<SqueezePage>>(getRepositoryToken(SqueezePage));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(squeezePagesService).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a new squeeze page', async () => {
+      const createSqueezePageDto: CreateSqueezePageDto = {
+        page_title: 'Test Squeeze Page',
+        url_slug: 'test-squeeze-page',
+        headline: 'Test Squeeze Page Content',
+        sub_headline: 'Test Squeeze Page Subheadline',
+        body: 'Test Squeeze Page Body',
+        image: 'test-squeeze-page.jpg',
+      };
+
+      const squeezePage = new SqueezePage();
+      Object.assign(squeezePage, createSqueezePageDto);
+
+      mockSqueezePageRepository.save.mockResolvedValue(squeezePage);
+
+      const result = await squeezePagesService.create(createSqueezePageDto);
+
+      expect(mockSqueezePageRepository.save).toHaveBeenCalledWith(squeezePage);
+      expect(result).toEqual({
+        status: 'success',
+        status_code: 201,
+        message: 'Squeeze Page created successfully.',
+        data: {
+          squeeze_page: squeezePage,
+        },
+      });
+    });
+  });
+
+  describe('findUriSlugs', () => {
+    it('should return all uri slugs', async () => {
+      const squeezePagesSlug: Partial<SqueezePage>[] = [
+        { url_slug: 'test-squeeze-page' },
+        { url_slug: 'test-squeeze-page-2' },
+      ];
+
+      mockSqueezePageRepository.find.mockResolvedValue(squeezePagesSlug);
+
+      const result = await squeezePagesService.findUriSlugs();
+
+      expect(mockSqueezePageRepository.find).toHaveBeenCalledWith({ select: ['url_slug'] });
+      expect(result).toEqual({
+        status: 'success',
+        status_code: 200,
+        message: 'Squeeze Pages retrieved successfully.',
+        data: {
+          squeeze_pages_slug_uri: squeezePagesSlug.map(squeezePage => squeezePage.url_slug),
+        },
+      });
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all squeeze pages', async () => {
+      const squeezePages: SqueezePage[] = [
+        {
+          id: 'valid-id-1',
+          page_title: 'Test Squeeze Page',
+          url_slug: 'test-squeeze-page',
+          headline: 'Test Squeeze Page Content',
+          sub_headline: 'Test Squeeze Page Subheadline',
+          body: 'Test Squeeze Page Body',
+          image: 'test-squeeze-page.jpg',
+          status: false,
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+        {
+          id: 'valid-id-2',
+          page_title: 'Test Squeeze Page 2',
+          url_slug: 'test-squeeze-page-2',
+          headline: 'Test Squeeze Page Content 2',
+          sub_headline: 'Test Squeeze Page Subheadline 2',
+          body: 'Test Squeeze Page Body 2',
+          image: 'test-squeeze-page-2.jpg',
+          status: false,
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+      ];
+
+      mockSqueezePageRepository.findAndCount.mockResolvedValue([squeezePages, squeezePages.length]);
+
+      const result = await squeezePagesService.findAll();
+
+      expect(mockSqueezePageRepository.findAndCount).toHaveBeenCalled();
+
+      expect(result).toEqual({
+        status: 'success',
+        status_code: 200,
+        message: 'Squeeze Pages retrieved successfully.',
+        data: {
+          squeeze_pages: squeezePages,
+          total: squeezePages.length,
+        },
+      });
+    });
+  });
+
+  describe('findPaginated', () => {
+    it('should return paginated squeeze pages', async () => {
+      const pageNumber = 1;
+      const limit = 10;
+      const squeezePages: SqueezePage[] = [
+        {
+          id: 'valid-id-1',
+          page_title: 'Test Squeeze Page',
+          url_slug: 'test-squeeze-page',
+          headline: 'Test Squeeze Page Content',
+          sub_headline: 'Test Squeeze Page Subheadline',
+          body: 'Test Squeeze Page Body',
+          image: 'test-squeeze-page.jpg',
+          status: false,
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+        {
+          id: 'valid-id-2',
+          page_title: 'Test Squeeze Page 2',
+          url_slug: 'test-squeeze-page-2',
+          headline: 'Test Squeeze Page Content 2',
+          sub_headline: 'Test Squeeze Page Subheadline 2',
+          body: 'Test Squeeze Page Body 2',
+          image: 'test-squeeze-page-2.jpg',
+          status: false,
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+      ];
+
+      mockSqueezePageRepository.findAndCount.mockResolvedValue([squeezePages, squeezePages.length]);
+
+      const result = await squeezePagesService.findPaginated(pageNumber, limit);
+
+      expect(mockSqueezePageRepository.findAndCount).toHaveBeenCalledWith({
+        skip: (pageNumber - 1) * limit,
+        take: limit,
+      });
+
+      expect(result).toEqual({
+        status: 'success',
+        status_code: 200,
+        message: 'Squeeze Pages retrieved successfully.',
+        data: {
+          squeeze_pages: squeezePages,
+          total: squeezePages.length,
+        },
+      });
+    });
+  });
+
+  describe('findByTitle', () => {
+    it('should return a single squeeze page by title', async () => {
+      const title = 'Test Squeeze Page';
+      const squeezePage: SqueezePage = {
+        id: 'valid-id-1',
+        page_title: title,
+        url_slug: 'test-squeeze-page',
+        headline: 'Test Squeeze Page Content',
+        sub_headline: 'Test Squeeze Page Subheadline',
+        body: 'Test Squeeze Page Body',
+        image: 'test-squeeze-page.jpg',
+        status: false,
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+
+      mockSqueezePageRepository.findAndCount.mockResolvedValue([squeezePage, 1]);
+
+      const result = await squeezePagesService.findByTitle(title);
+
+      expect(mockSqueezePageRepository.findAndCount).toHaveBeenCalledWith({ where: { page_title: title } });
+      expect(result).toEqual({
+        status: 'success',
+        status_code: 200,
+        message: 'Squeeze Pages retrieved successfully.',
+        data: {
+          squeeze_page: squeezePage,
+          total: 1,
+        },
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('should update a squeeze page', async () => {
+      const id = 'valid-id-1';
+      const updateSqueezePageDto: UpdateSqueezePageDto = {
+        page_title: 'Test Squeeze Page update',
+        url_slug: 'test-squeeze-page url update',
+        headline: 'Test Squeeze Page Content update',
+        sub_headline: 'Test Squeeze Page Subheadline update',
+        body: 'Test Squeeze Page Body update',
+        image: 'test-squeeze-page.jpg update',
+      };
+
+      const squeezePage: SqueezePage = {
+        id,
+        page_title: 'Test Squeeze Page',
+        url_slug: 'test-squeeze-page',
+        headline: 'Test Squeeze Page Content',
+        sub_headline: 'Test Squeeze Page Subheadline',
+        body: 'Test Squeeze Page Body',
+        image: 'test-squeeze-page.jpg',
+        status: false,
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+
+      const updatedSqueezePage: SqueezePage = Object.assign(squeezePage, updateSqueezePageDto);
+
+      mockSqueezePageRepository.findOne.mockResolvedValue(squeezePage);
+      mockSqueezePageRepository.save.mockResolvedValue(updatedSqueezePage);
+      const result = await squeezePagesService.update(id, updateSqueezePageDto);
+
+      expect(mockSqueezePageRepository.findOne).toHaveBeenCalledWith({ where: { id } });
+      expect(mockSqueezePageRepository.save).toHaveBeenCalledWith(updatedSqueezePage);
+      expect(result).toEqual({
+        status: 'success',
+        status_code: 200,
+        message: 'Squeeze Page updated successfully.',
+        data: {
+          squeeze_page: updatedSqueezePage,
+        },
+      });
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a squeeze page', async () => {
+      const id = 'valid-id-1';
+      const squeezePage: SqueezePage = {
+        id,
+        page_title: 'Test Squeeze Page',
+        url_slug: 'test-squeeze-page',
+        headline: 'Test Squeeze Page Content',
+        sub_headline: 'Test Squeeze Page Subheadline',
+        body: 'Test Squeeze Page Body',
+        image: 'test-squeeze-page.jpg',
+        status: false,
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+
+      mockSqueezePageRepository.findOne.mockResolvedValue(squeezePage);
+      mockSqueezePageRepository.remove.mockResolvedValue(squeezePage);
+
+      const result = await squeezePagesService.remove(id);
+
+      expect(mockSqueezePageRepository.findOne).toHaveBeenCalledWith({ where: { id } });
+      expect(mockSqueezePageRepository.remove).toHaveBeenCalledWith(squeezePage);
+      expect(result).toEqual({
+        status: 'success',
+        status_code: 200,
+        message: 'Squeeze Page removed successfully.',
+      });
+    });
+  });
+});


### PR DESCRIPTION
### What does the PR do?
This PR implements super admin squeeze page  CRUD operations. Super admin can create, update, get, and delete squeeze page(s).

### How should this be manually tested?
To test this feature, you can send a request matching the method specified to the following endpoint:

**Create Squeeze Pages:**

Endpoint: `POST /api/v1/squeeze-pages`

Request Body:
```json
{
    "page_title": "String",
    "url_slug": "String",
    "headline": "String",
    "sub_headline": "String",
    "body": "String",
    "image?": "String",   
}
```

Response (Success):
```json
{
    "status": "String",
    "status_code": "Number",
    "message": "String",
    "data": {
    "squeeze_page": {
        "id": "String",
        "page_title": "String",
        "url_slug": "String",
        "headline": "String",
        "sub_headline": "String",
        "body": "String",
        "image": "String",
        "status": "Boolean",
        "created_at": "Date",
        "updated_at": "Date"
        }
    }
}
```

**Get Squeeze Page:**

Endpoint: `GET /api/v1/squeeze-pages`

Response (Success):
```json
{
    "status": "String",
    "status_code": "Number",
    "message": "String",
    "data": {
    "squeeze_pages": [
        {
        "id": "String",
        "page_title": "String",
        "url_slug": "String",
        "headline": "String",
        "sub_headline": "String",
        "body": "String",
        "image": "String",
        "status": "Boolean",
        "created_at": "Date",
        "updated_at": "Date"
        }
    ]
    }
}
```

**Get Squeeze Pages Slugs URI:**

Endpoint: `GET /api/v1/squeeze-pages/uri-slugs`

Response (Success):
```json
{
    "status": "String",
    "status_code": "Number",
    "message": "String",
    "data": {
    "squeeze_pages": [
        "String"
    ]
    }
}
```

**Update Squeeze Page:**

Endpoint: `PATCH /api/v1/squeeze-pages/{id}`

Request Body:
```json
{
    "page_title?": "String",
    "url_slug?": "String",
    "headline?": "String",
    "sub_headline?": "String",
    "body?": "String",
    "image?": "String",   
}
```

Response (Success):
```json
{
    "status": "String",
    "status_code": "Number",
    "message": "String",
    "data": {
    "squeeze_page": {
        "id": "String",
        "page_title": "String",
        "url_slug": "String",
        "headline": "String",
        "sub_headline": "String",
        "body": "String",
        "image": "String",
        "status": "Boolean",
        "created_at": "Date",
        "updated_at": "Date"
        }
    }
}
```

**Delete Squeeze Page:**

Endpoint: `DELETE /api/v1/squeeze-pages/{id}`

Response (Success):
```json
{
    "status": "String",
    "status_code": "Number",
    "message": "String"
}
```

Response (Error):

```json
{
  "message": "String",
  "status_code": "Number"
}
```

### Acceptance Criteria
- Implement endpoints for reading, updating, and deleting squeeze pages.
- Validate input data for each operation.
- updating and deleting squeeze pages should require super admin authorization.
- Validate user input on the server side.
- Ensure only authenticated and authorized users can perform CRUD operations on squeeze pages.
- Display clear error messages for invalid inputs.
- Ensure that the squeeze page is created successfully.
- Ensure that the squeeze page is updated successfully.
- Ensure that the squeeze page is deleted successfully.
- Ensure that the squeeze page is retrieved successfully.
- Ensure that the squeeze page slugs are retrieved successfully.
  
### Checklist
- [x] I have performed a self-review of my own code
- [x] I have written unit tests for my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
  
### Tests screenshot
![image](https://github.com/user-attachments/assets/19193614-e10b-45ee-a9af-a3da2919dbb0)
