### PR TITLE
fix: newsletter subscription

### DIFF
--- a/src/modules/newsletter-subscription/dto/newsletter-subscription.response.dto.ts
+++ b/src/modules/newsletter-subscription/dto/newsletter-subscription.response.dto.ts
@@ -1,0 +1,4 @@
+export class NewsletterSubscriptionResponseDto {
+  id: string;
+  email: string;
+}

--- a/src/modules/newsletter-subscription/newsletter-subscripion.controller.ts
+++ b/src/modules/newsletter-subscription/newsletter-subscripion.controller.ts
@@ -4,6 +4,7 @@ import { CreateNewsletterSubscriptionDto } from './dto/create-newsletter-subscri
 import { skipAuth } from '../../helpers/skipAuth';
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { SuperAdminGuard } from '../../guards/super-admin.guard';
+import { NewsletterSubscriptionResponseDto } from './dto/newsletter-subscription.response.dto';
 
 @ApiTags('Newsletter Subscription')
 @Controller('newsletter-subscription')
@@ -23,9 +24,26 @@ export class NewsletterSubscriptionController {
   @Get()
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Fetch all subscribers to newsletter' })
-  @ApiResponse({ status: 200, type: [Object] })
-  findAll() {
-    return this.newsletterSubscriptionService.findAll();
+  @ApiResponse({
+    status: 200,
+    description: 'Return all team members',
+    schema: {
+      properties: {
+        status: { type: 'string' },
+        message: { type: 'string' },
+        data: {
+          type: 'array',
+          items: { $ref: '#/components/schemas/NewsletterSubscriptionResponseDto' },
+        },
+      },
+    },
+  })
+  async findAll(): Promise<{ message: string; data: NewsletterSubscriptionResponseDto[] }> {
+    const subscribers = await this.newsletterSubscriptionService.findAll();
+    return {
+      message: 'Subscriber list fetched successfully',
+      data: subscribers,
+    };
   }
 
   @UseGuards(SuperAdminGuard)

--- a/src/modules/newsletter-subscription/newsletter-subscripion.controller.ts
+++ b/src/modules/newsletter-subscription/newsletter-subscripion.controller.ts
@@ -41,7 +41,7 @@ export class NewsletterSubscriptionController {
   async findAll(): Promise<{ message: string; data: NewsletterSubscriptionResponseDto[] }> {
     const subscribers = await this.newsletterSubscriptionService.findAll();
     return {
-      message: 'Subscriber list fetched successfully',
+      message: 'Subscribers list fetched successfully',
       data: subscribers,
     };
   }
@@ -61,9 +61,27 @@ export class NewsletterSubscriptionController {
   @Get('deleted')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Fetch all deleted subscribers' })
-  @ApiResponse({ status: 200, type: [Object] })
-  findSoftDeleted() {
-    return this.newsletterSubscriptionService.findSoftDeleted();
+  @ApiResponse({
+    status: 200,
+    description: 'Return all team members',
+    schema: {
+      properties: {
+        status: { type: 'string' },
+        message: { type: 'string' },
+        data: {
+          type: 'array',
+          items: { $ref: '#/components/schemas/NewsletterSubscriptionResponseDto' },
+        },
+      },
+    },
+  })
+  async findSoftDeleted(): Promise<{ message: string; data: NewsletterSubscriptionResponseDto[] }> {
+    const deletedSubscribers = await this.newsletterSubscriptionService.findSoftDeleted();
+
+    return {
+      message: 'Deleted subscribers list fetched successfully',
+      data: deletedSubscribers,
+    };
   }
 
   @UseGuards(SuperAdminGuard)

--- a/src/modules/newsletter-subscription/newsletter-subscription.service.ts
+++ b/src/modules/newsletter-subscription/newsletter-subscription.service.ts
@@ -3,6 +3,7 @@ import { CreateNewsletterSubscriptionDto } from './dto/create-newsletter-subscri
 import { InjectRepository } from '@nestjs/typeorm';
 import { IsNull, Not, Repository } from 'typeorm';
 import { NewsletterSubscription } from './entities/newsletter-subscription.entity';
+import { NewsletterSubscriptionResponseDto } from './dto/newsletter-subscription.response.dto';
 
 @Injectable()
 export class NewsletterSubscriptionService {
@@ -24,13 +25,10 @@ export class NewsletterSubscriptionService {
     return response;
   }
 
-  async findAll() {
+  async findAll(): Promise<NewsletterSubscriptionResponseDto[]> {
     const subscribers = await this.newsletterSubscriptionRepository.find();
 
-    return subscribers.map(newsletter => ({
-      id: newsletter.id,
-      email: newsletter.email,
-    }));
+    return subscribers.map(this.mapSubscriberToResponseDto);
   }
 
   async remove(id: string) {
@@ -55,5 +53,14 @@ export class NewsletterSubscriptionService {
       throw new NotFoundException(`Subscriber with ID ${id} not found or already restored`);
     }
     return { message: `Subscriber with ID ${id} has been restored` };
+  }
+
+  private mapSubscriberToResponseDto(
+    newsletterSubscription: NewsletterSubscription
+  ): NewsletterSubscriptionResponseDto {
+    return {
+      id: newsletterSubscription.id,
+      email: newsletterSubscription.email,
+    };
   }
 }

--- a/src/modules/teams/teams.controller.ts
+++ b/src/modules/teams/teams.controller.ts
@@ -25,17 +25,51 @@ export class TeamsController {
 
   @Get()
   @ApiOperation({ summary: 'Get all team members' })
-  @ApiResponse({ status: 200, description: 'Return all team members', type: [TeamMemberResponseDto] })
-  findAll(): Promise<TeamMemberResponseDto[]> {
-    return this.teamsService.findAllTeamMembers();
+  @ApiResponse({
+    status: 200,
+    description: 'Return all team members',
+    schema: {
+      properties: {
+        status: { type: 'string' },
+        message: { type: 'string' },
+        data: {
+          type: 'array',
+          items: { $ref: '#/components/schemas/TeamMemberResponseDto' },
+        },
+      },
+    },
+  })
+  async findAll(): Promise<{ message: string; data: TeamMemberResponseDto[] }> {
+    const teamMembers = await this.teamsService.findAllTeamMembers();
+    return {
+      message: 'Team members retrieved successfully',
+      data: teamMembers,
+    };
   }
 
   @Get(':id')
   @ApiOperation({ summary: 'Get a team member by id' })
   @ApiParam({ name: 'id', description: 'The id of the team member' })
-  @ApiResponse({ status: 200, description: 'Return the team member', type: TeamMemberResponseDto })
-  findOne(@Param('id') id: string): Promise<TeamMemberResponseDto> {
-    return this.teamsService.findOneTeamMember(id);
+  @ApiResponse({
+    status: 200,
+    description: 'Return the team member',
+    schema: {
+      properties: {
+        status: { type: 'string' },
+        message: { type: 'string' },
+        data: {
+          type: 'object',
+          items: { $ref: '#/components/schemas/TeamMemberResponseDto' },
+        },
+      },
+    },
+  })
+  async findOne(@Param('id') id: string): Promise<{ message: string; data: TeamMemberResponseDto }> {
+    const teamMember = await this.teamsService.findOneTeamMember(id);
+    return {
+      message: 'Team member fetched successfully',
+      data: teamMember,
+    };
   }
 
   @UseGuards(SuperAdminGuard)


### PR DESCRIPTION
 ## What does this PR do?

This PR indicates the changes made to the `GET` request responses on the teams endpoint.

* Fixed `GET /api/v1/newsletter-subscription` endpoint response
* Added `GET /api/v1/newsletter-subscription/deleted` endpoint response
* Updated API documentation to reflect the new endpoint.

## Response Example

### Fetch All Subscribers
**Success**

```json
{
    "status": 200,
    "message": "string",
    "data": [
        {
            "id": "string",
            "email": "string"
        },
        {
            "id": "string",
            "email": "string"
        }
    ]
}
```

### Get Removed Subscriber from List
```json
{
    "status": 200,
    "message": "string",
    "data": [
        {
            "id": "string",
            "email": "string"
        },
        {
            "id": "string",
            "email": "string"
        }
    ]
}
```

## Link to Merged PR
[feat: newsletter subscription](https://github.com/hngprojects/hng_boilerplate_nestjs/pull/607)