### PR TITLE
fix: existing endpoints for reseting password

### DIFF
--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -90,8 +90,12 @@ export default class AuthenticationService {
   }
 
   async updateForgotPassword(updatePasswordDto: UpdatePasswordDto) {
-    const { newPassword, otp } = updatePasswordDto;
-    const user = await this.otpService.retrieveUserAndOtp(otp);
+    const { email, newPassword, otp } = updatePasswordDto;
+
+    const exists = await this.userService.getUserRecord({ identifier: email, identifierType: 'email' });
+    if (!exists) throw new CustomHttpException(SYS_MSG.USER_ACCOUNT_DOES_NOT_EXIST, HttpStatus.NOT_FOUND);
+
+    const user = await this.otpService.retrieveUserAndOtp(exists.id, otp);
 
     return this.userService.updateUser(user.id, { password: newPassword }, user);
   }

--- a/src/modules/auth/dto/updatePasswordDto.ts
+++ b/src/modules/auth/dto/updatePasswordDto.ts
@@ -1,12 +1,27 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsString, IsStrongPassword, MinLength } from 'class-validator';
 
 export class UpdatePasswordDto {
   @ApiProperty({
+    description: 'The email address of the user',
+    example: 'john@example.com',
+  })
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+
+  @ApiProperty({
     description: 'The new password of the user',
   })
-  @IsString()
+  @MinLength(8)
   @IsNotEmpty()
+  @IsStrongPassword(
+    {},
+    {
+      message:
+        'Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character.',
+    }
+  )
   newPassword: string;
 
   @ApiProperty({

--- a/src/modules/email/templates/reset-password.hbs
+++ b/src/modules/email/templates/reset-password.hbs
@@ -27,8 +27,7 @@
       <div class='content'>
         <h1>Forgot Password</h1>
         <p>Hello {{email}},</p>
-        <p>It seems like you forgot your password. Click the button below to reset it:</p>
-        <a href='{{link}}' class='btn'>Reset Password</a>
+        <p>It seems like you forgot your password. use this otp to reset your password: <strong>{{token}}</strong></p>
         <p>If you didn't request a password reset, please ignore this email.</p>
       </div>
       <div class='footer'>

--- a/src/modules/otp/otp.service.ts
+++ b/src/modules/otp/otp.service.ts
@@ -65,8 +65,8 @@ export class OtpService {
     return otp;
   }
 
-  async retrieveUserAndOtp(token: string): Promise<User | null> {
-    const otp = await this.otpRepository.findOne({ where: { token }, relations: ['user'] });
+  async retrieveUserAndOtp(user_id: string, token: string): Promise<User | null> {
+    const otp = await this.otpRepository.findOne({ where: { token, user_id }, relations: ['user'] });
 
     if (!otp) throw new CustomHttpException('OTP is invalid', HttpStatus.BAD_REQUEST);
 

--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -1,5 +1,5 @@
 import * as bcrypt from 'bcryptjs';
-import { BeforeInsert, Column, Entity, JoinColumn, OneToMany, OneToOne } from 'typeorm';
+import { BeforeInsert, BeforeUpdate, Column, Entity, JoinColumn, OneToMany, OneToOne } from 'typeorm';
 import { AbstractBaseEntity } from '../../../entities/base.entity';
 import { Job } from '../../../modules/jobs/entities/job.entity';
 import { NotificationSettings } from '../../../modules/notification-settings/entities/notification-setting.entity';
@@ -77,6 +77,7 @@ export class User extends AbstractBaseEntity {
   organisationMembers: OrganisationMember[];
 
   @BeforeInsert()
+  @BeforeUpdate()
   async hashPassword() {
     this.password = await bcrypt.hash(this.password, 10);
   }


### PR DESCRIPTION
# What does this PR do
This PR fixes the endpoints to handle password reset requests for registered users who have forgotten their passwords. The endpoint ensures secure password updates by validating necessary fields, verifying tokens. On successful password reset, a 200 status code is returned along with a success message. Appropriate error statuses are returned in case of errors.

Endpoints:

[POST] /api/v1/auth/forgot-password
Description: Initiates password reset process by verifying the user's email and sending a reset token.
Request Body: { "email": "string" }
Responses:
200 OK: If a user with that email exists, a password reset link is sent.
400 Bad Request: Invalid email.
500 Internal Server Error: Server error.
[POST] /api/v1/auth/reset-password

Description: Resets the user's password using the received reset token.
Request Body: { "newPassword": "string", "email": "string, "otp": "string" }
Responses:
200 OK: Password updated successfully.
400 Bad Request: Invalid input or token.
500 Internal Server Error: Server error.