### PR TITLE
feat: delete user profile

### DIFF
--- a/src/modules/profile/entities/profile.entity.ts
+++ b/src/modules/profile/entities/profile.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToOne, JoinColumn } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, OneToOne, JoinColumn, DeleteDateColumn } from 'typeorm';
 import { User } from '../../user/entities/user.entity';
 import { AbstractBaseEntity } from '../../../entities/base.entity';
 
@@ -36,4 +36,7 @@ export class Profile extends AbstractBaseEntity {
 
   @Column({ nullable: true })
   profile_pic_url: string;
+
+  @DeleteDateColumn()
+  deletedAt?: Date;
 }

--- a/src/modules/profile/profile.controller.ts
+++ b/src/modules/profile/profile.controller.ts
@@ -1,11 +1,13 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseInterceptors } from '@nestjs/common';
 import { ProfileService } from './profile.service';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { UpdateProfileDto } from './dto/update-profile.dto';
+import { ResponseInterceptor } from 'src/shared/inteceptors/response.interceptor';
 
 @ApiBearerAuth()
 @ApiTags('Profile')
 @Controller('profile')
+@UseInterceptors(ResponseInterceptor)
 export class ProfileController {
   constructor(private readonly profileService: ProfileService) {}
 

--- a/src/modules/profile/profile.controller.ts
+++ b/src/modules/profile/profile.controller.ts
@@ -30,4 +30,14 @@ export class ProfileController {
     const updatedProfile = this.profileService.updateProfile(userId, body);
     return updatedProfile;
   }
+
+  @ApiOperation({ summary: 'Delete User Profile' })
+  @ApiResponse({
+    status: 200,
+    description: 'The deleted record',
+  })
+  @Delete(':userId')
+  async deleteUserProfile(@Param('userId') userId: string) {
+    return await this.profileService.deleteUserProfile(userId);
+  }
 }

--- a/src/modules/profile/profile.service.ts
+++ b/src/modules/profile/profile.service.ts
@@ -85,8 +85,6 @@ export class ProfileService {
         where: { id: user.profile.id },
       });
 
-      console.log(userProfile, 'user profile');
-
       if (!userProfile) {
         throw new NotFoundException('Profile not found');
       }

--- a/src/modules/profile/profile.service.ts
+++ b/src/modules/profile/profile.service.ts
@@ -74,33 +74,26 @@ export class ProfileService {
     }
   }
   async deleteUserProfile(userId: string) {
-    try {
-      const user = await this.userRepository.findOne({ where: { id: userId }, relations: ['profile'] });
+    const user = await this.userRepository.findOne({ where: { id: userId }, relations: ['profile'] });
 
-      if (!user || !user.profile) {
-        throw new NotFoundException('User profile not found');
-      }
-
-      const userProfile = await this.profileRepository.findOne({
-        where: { id: user.profile.id },
-      });
-
-      if (!userProfile) {
-        throw new NotFoundException('Profile not found');
-      }
-
-      await this.profileRepository.softDelete(userProfile.id);
-
-      const responseData = {
-        message: 'Profile successfully deleted',
-      };
-
-      return responseData;
-    } catch (error) {
-      if (error instanceof NotFoundException || error instanceof BadRequestException) {
-        throw error;
-      }
-      throw new InternalServerErrorException(`Internal server error: ${error.message}`);
+    if (!user || !user.profile) {
+      throw new NotFoundException('User profile not found');
     }
+
+    const userProfile = await this.profileRepository.findOne({
+      where: { id: user.profile.id },
+    });
+
+    if (!userProfile) {
+      throw new NotFoundException('Profile not found');
+    }
+
+    await this.profileRepository.softDelete(userProfile.id);
+
+    const responseData = {
+      message: 'Profile successfully deleted',
+    };
+
+    return responseData;
   }
 }

--- a/src/modules/profile/profile.service.ts
+++ b/src/modules/profile/profile.service.ts
@@ -73,4 +73,36 @@ export class ProfileService {
       throw new InternalServerErrorException(`Internal server error: ${error.message}`);
     }
   }
+  async deleteUserProfile(userId: string) {
+    try {
+      const user = await this.userRepository.findOne({ where: { id: userId }, relations: ['profile'] });
+
+      if (!user || !user.profile) {
+        throw new NotFoundException('User profile not found');
+      }
+
+      const userProfile = await this.profileRepository.findOne({
+        where: { id: user.profile.id },
+      });
+
+      console.log(userProfile, 'user profile');
+
+      if (!userProfile) {
+        throw new NotFoundException('Profile not found');
+      }
+
+      await this.profileRepository.softDelete(userProfile.id);
+
+      const responseData = {
+        message: 'Profile successfully deleted',
+      };
+
+      return responseData;
+    } catch (error) {
+      if (error instanceof NotFoundException || error instanceof BadRequestException) {
+        throw error;
+      }
+      throw new InternalServerErrorException(`Internal server error: ${error.message}`);
+    }
+  }
 }

--- a/src/modules/profile/tests/profile.service.spec.ts
+++ b/src/modules/profile/tests/profile.service.spec.ts
@@ -167,12 +167,5 @@ describe('ProfileService', () => {
       expect(profileRepository.findOne).toHaveBeenCalledWith({ where: { id: 'profileId' } });
       expect(profileRepository.softDelete).toHaveBeenCalledWith('profileId');
     });
-
-    it('should throw InternalServerErrorException on unexpected error', async () => {
-      jest.spyOn(userRepository, 'findOne').mockRejectedValue(new Error('Unexpected error'));
-
-      await expect(service.deleteUserProfile('userId')).rejects.toThrow(InternalServerErrorException);
-      expect(userRepository.findOne).toHaveBeenCalledWith({ where: { id: 'userId' }, relations: ['profile'] });
-    });
   });
 });


### PR DESCRIPTION
# What does this PR do?
This PR implements an endpoint for deleting user profile:
* Added DELETE /api/v1/profile/:id Endpoint: Deletes a user's profile
* Authentication: Ensures only authenticated users can access these endpoints.
* Authorization: Ensures only users or admin can access this route.
* Error Handling: Returns specific HTTP status codes and messages based on various scenarios.

# Checklist:
- [x] Implemented DELETE /api/v1/profile/:id to delete the current user's profile settings.
- [x] Implemented an endpoint to delete user profile settings.
- [x] Return 200 OK on successful deletion.
- [x] Return 401 Unauthorized if the user is not authenticated.
- [x] Tested endpoint functionality to ensure it correctly handles various scenarios.
- [x] Added appropriate HTTP status codes and response messages for edge cases.
- [x] Added unit tests for the deleteProfile() method
- [x] Updated API documentation to reflect the new endpoint.

# Response Examples
**Success**

```json
{
    "status": "success",
    "message": "User profile deleted successfully"
}
```

# Link to Issue
Link to this issue: [FEAT Create API Endpoints to Delete User Profile](https://github.com/hngprojects/hng_boilerplate_nestjs/issues/167)