### PR TITLE
feat: create endpoint for Add a Product for Super-admin

### DIFF
--- a/src/modules/products/products.superadmin.controller.ts
+++ b/src/modules/products/products.superadmin.controller.ts
@@ -1,0 +1,26 @@
+import { Body, Controller, Delete, Get, HttpCode, Param, Patch, Post, UseGuards, Query } from '@nestjs/common';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { OwnershipGuard } from '../../guards/authorization.guard';
+import { CreateProductRequestDto } from './dto/create-product.dto';
+import { ProductsService } from './products.service';
+import { UpdateProductDTO } from './dto/update-product.dto';
+import { SuperAdminGuard } from 'src/guards/super-admin.guard';
+
+@ApiTags('add-Product-superAdmin')
+@Controller('admin/products/:id')
+export class ProductsController {
+  constructor(private readonly productsService: ProductsService) {}
+
+  @UseGuards(SuperAdminGuard)
+  @Post('')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Creates a new product by super admin' })
+  @ApiParam({ name: 'id', description: 'organisation ID', example: '12345' })
+  @ApiBody({ type: CreateProductRequestDto, description: 'Details of the product to be created' })
+  @ApiResponse({ status: 201, description: 'Product created successfully' })
+  @ApiResponse({ status: 400, description: 'Bad request' })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  async createProductBySuperAdmin(@Param('id') id: string, @Body() createProductDto: CreateProductRequestDto) {
+    return this.productsService.createProduct(id, createProductDto);
+  }
+}


### PR DESCRIPTION
Develop a new endpoint that allows a Super-Admin to add a new product to the system. This endpoint should ensure that only users with Super-Admin privileges can access it. 

###Acceptance Criteria###

##Endpoint URL##
##POST##
`/api/super-admin/products`

*Request Headers*
Authorization: SuperadminGuard
Content-Type: application/json

*Request Body*
```json
{
  "name": "Product Name",
  "description": "Product Description",
  "price": 100.0,
  "category": "Product Category",
  "availability": true
}
```
*Response*
-Success (201 Created)
```json
{
  "message": "Product added successfully",
  "product": {
    "id": "Product ID",
    "name": "Product Name",
    "description": "Product Description",
    "price": 100.0,
    "status": "in stock",
    "quantity": "20",
    "createdAt": "Timestamp",
    "updatedAt": "Timestamp"
  }
}
```
-Error Response
Error(400 Bad Request)
```json
{
  "message": "Bad request "
}
```
Error (500 Internal Server Error)
```json
{
"message": "An error occurred while adding the product"
}
```


