### PR TITLE
feat: user soft deletion

### DIFF
--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -1,5 +1,5 @@
 import * as bcrypt from 'bcryptjs';
-import { BeforeInsert, BeforeUpdate, Column, Entity, JoinColumn, OneToMany, OneToOne } from 'typeorm';
+import { BeforeInsert, BeforeUpdate, Column, DeleteDateColumn, Entity, JoinColumn, OneToMany, OneToOne } from 'typeorm';
 import { AbstractBaseEntity } from '../../../entities/base.entity';
 import { Job } from '../../../modules/jobs/entities/job.entity';
 import { NotificationSettings } from '../../../modules/notification-settings/entities/notification-setting.entity';
@@ -55,6 +55,9 @@ export class User extends AbstractBaseEntity {
 
   @Column({ default: false })
   is_2fa_enabled: boolean;
+
+  @DeleteDateColumn({ nullable: true })
+  deletedAt?: Date;
 
   @OneToMany(() => Organisation, organisation => organisation.owner)
   owned_organisations: Organisation[];

--- a/src/modules/user/tests/user.service.spec.ts
+++ b/src/modules/user/tests/user.service.spec.ts
@@ -562,7 +562,7 @@ describe('UserService', () => {
       expect(result.message).toBe('Deletion in progress');
       expect(mockUserRepository.findOne).toHaveBeenCalledWith({
         where: { id: userId },
-        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
+        relations: ['profile', 'owned_organisations'],
       });
       expect(mockUserRepository.softDelete).toHaveBeenCalledWith(userId);
     });
@@ -579,7 +579,7 @@ describe('UserService', () => {
       );
       expect(mockUserRepository.findOne).toHaveBeenCalledWith({
         where: { id: userId },
-        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
+        relations: ['profile', 'owned_organisations'],
       });
       expect(mockUserRepository.softDelete).not.toHaveBeenCalled();
     });
@@ -606,82 +606,7 @@ describe('UserService', () => {
       );
       expect(mockUserRepository.findOne).toHaveBeenCalledWith({
         where: { id: userId },
-        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
-      });
-      expect(mockUserRepository.softDelete).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('softDeleteUser', () => {
-    it('should soft delete a user', async () => {
-      const userId = '1';
-      const authenticatedUserId = '1';
-      const userToDelete = {
-        id: '1',
-        first_name: 'John',
-        last_name: 'Doe',
-        email: 'test@example.com',
-        password: 'hashedpassword',
-        is_active: true,
-        attempts_left: 3,
-        time_left: 60,
-      };
-
-      mockUserRepository.findOne.mockResolvedValueOnce(userToDelete);
-      mockUserRepository.softDelete.mockResolvedValueOnce({ affected: 1 });
-      mockUserRepository.softDelete.mockResolvedValueOnce({ affected: 1 });
-
-      const result = await service.softDeleteUser(userId, authenticatedUserId);
-
-      expect(result.status).toBe('success');
-      expect(result.message).toBe('Deletion in progress');
-      expect(mockUserRepository.findOne).toHaveBeenCalledWith({
-        where: { id: userId },
-        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
-      });
-      expect(mockUserRepository.softDelete).toHaveBeenCalledWith(userId);
-    });
-
-    it('should throw an error if user is not found', async () => {
-      const userId = '1';
-      const authenticatedUserId = '1';
-
-      mockUserRepository.findOne.mockResolvedValueOnce(null);
-
-      await expect(service.softDeleteUser(userId, authenticatedUserId)).rejects.toHaveProperty(
-        'response',
-        'User not found'
-      );
-      expect(mockUserRepository.findOne).toHaveBeenCalledWith({
-        where: { id: userId },
-        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
-      });
-      expect(mockUserRepository.softDelete).not.toHaveBeenCalled();
-    });
-
-    it('should throw an error if the user is not authorized to delete the user', async () => {
-      const userId = '1';
-      const authenticatedUserId = '2';
-      const userToDelete = {
-        id: '1',
-        first_name: 'John',
-        last_name: 'Doe',
-        email: 'test@example.com',
-        password: 'hashedpassword',
-        is_active: true,
-        attempts_left: 3,
-        time_left: 60,
-      };
-
-      mockUserRepository.findOne.mockResolvedValueOnce(userToDelete);
-
-      await expect(service.softDeleteUser(userId, authenticatedUserId)).rejects.toHaveProperty(
-        'response',
-        'You are not authorized to delete this user'
-      );
-      expect(mockUserRepository.findOne).toHaveBeenCalledWith({
-        where: { id: userId },
-        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
+        relations: ['profile', 'owned_organisations'],
       });
       expect(mockUserRepository.softDelete).not.toHaveBeenCalled();
     });

--- a/src/modules/user/tests/user.service.spec.ts
+++ b/src/modules/user/tests/user.service.spec.ts
@@ -562,7 +562,6 @@ describe('UserService', () => {
       expect(result.message).toBe('Deletion in progress');
       expect(mockUserRepository.findOne).toHaveBeenCalledWith({
         where: { id: userId },
-        relations: ['profile', 'owned_organisations'],
       });
       expect(mockUserRepository.softDelete).toHaveBeenCalledWith(userId);
     });
@@ -579,7 +578,6 @@ describe('UserService', () => {
       );
       expect(mockUserRepository.findOne).toHaveBeenCalledWith({
         where: { id: userId },
-        relations: ['profile', 'owned_organisations'],
       });
       expect(mockUserRepository.softDelete).not.toHaveBeenCalled();
     });
@@ -606,7 +604,6 @@ describe('UserService', () => {
       );
       expect(mockUserRepository.findOne).toHaveBeenCalledWith({
         where: { id: userId },
-        relations: ['profile', 'owned_organisations'],
       });
       expect(mockUserRepository.softDelete).not.toHaveBeenCalled();
     });

--- a/src/modules/user/tests/user.service.spec.ts
+++ b/src/modules/user/tests/user.service.spec.ts
@@ -23,6 +23,7 @@ describe('UserService', () => {
     findOne: jest.fn(),
     findAndCount: jest.fn(),
     count: jest.fn(),
+    softDelete: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -453,7 +454,6 @@ describe('UserService', () => {
         },
       });
     });
-
     describe('getUserStats', () => {
       it('should return user statistics for active status', async () => {
         const totalUsers = 100;
@@ -534,6 +534,156 @@ describe('UserService', () => {
         });
         expect(mockUserRepository.count).toHaveBeenCalledTimes(3);
       });
+    });
+  });
+
+  describe('softDeleteUser', () => {
+    it('should soft delete a user', async () => {
+      const userId = '1';
+      const authenticatedUserId = '1';
+      const userToDelete = {
+        id: '1',
+        first_name: 'John',
+        last_name: 'Doe',
+        email: 'test@example.com',
+        password: 'hashedpassword',
+        is_active: true,
+        attempts_left: 3,
+        time_left: 60,
+      };
+
+      mockUserRepository.findOne.mockResolvedValueOnce(userToDelete);
+      mockUserRepository.softDelete.mockResolvedValueOnce({ affected: 1 });
+      mockUserRepository.softDelete.mockResolvedValueOnce({ affected: 1 });
+
+      const result = await service.softDeleteUser(userId, authenticatedUserId);
+
+      expect(result.status).toBe('success');
+      expect(result.message).toBe('Deletion in progress');
+      expect(mockUserRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
+      });
+      expect(mockUserRepository.softDelete).toHaveBeenCalledWith(userId);
+    });
+
+    it('should throw an error if user is not found', async () => {
+      const userId = '1';
+      const authenticatedUserId = '1';
+
+      mockUserRepository.findOne.mockResolvedValueOnce(null);
+
+      await expect(service.softDeleteUser(userId, authenticatedUserId)).rejects.toHaveProperty(
+        'response',
+        'User not found'
+      );
+      expect(mockUserRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
+      });
+      expect(mockUserRepository.softDelete).not.toHaveBeenCalled();
+    });
+
+    it('should throw an error if the user is not authorized to delete the user', async () => {
+      const userId = '1';
+      const authenticatedUserId = '2';
+      const userToDelete = {
+        id: '1',
+        first_name: 'John',
+        last_name: 'Doe',
+        email: 'test@example.com',
+        password: 'hashedpassword',
+        is_active: true,
+        attempts_left: 3,
+        time_left: 60,
+      };
+
+      mockUserRepository.findOne.mockResolvedValueOnce(userToDelete);
+
+      await expect(service.softDeleteUser(userId, authenticatedUserId)).rejects.toHaveProperty(
+        'response',
+        'You are not authorized to delete this user'
+      );
+      expect(mockUserRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
+      });
+      expect(mockUserRepository.softDelete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('softDeleteUser', () => {
+    it('should soft delete a user', async () => {
+      const userId = '1';
+      const authenticatedUserId = '1';
+      const userToDelete = {
+        id: '1',
+        first_name: 'John',
+        last_name: 'Doe',
+        email: 'test@example.com',
+        password: 'hashedpassword',
+        is_active: true,
+        attempts_left: 3,
+        time_left: 60,
+      };
+
+      mockUserRepository.findOne.mockResolvedValueOnce(userToDelete);
+      mockUserRepository.softDelete.mockResolvedValueOnce({ affected: 1 });
+      mockUserRepository.softDelete.mockResolvedValueOnce({ affected: 1 });
+
+      const result = await service.softDeleteUser(userId, authenticatedUserId);
+
+      expect(result.status).toBe('success');
+      expect(result.message).toBe('Deletion in progress');
+      expect(mockUserRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
+      });
+      expect(mockUserRepository.softDelete).toHaveBeenCalledWith(userId);
+    });
+
+    it('should throw an error if user is not found', async () => {
+      const userId = '1';
+      const authenticatedUserId = '1';
+
+      mockUserRepository.findOne.mockResolvedValueOnce(null);
+
+      await expect(service.softDeleteUser(userId, authenticatedUserId)).rejects.toHaveProperty(
+        'response',
+        'User not found'
+      );
+      expect(mockUserRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
+      });
+      expect(mockUserRepository.softDelete).not.toHaveBeenCalled();
+    });
+
+    it('should throw an error if the user is not authorized to delete the user', async () => {
+      const userId = '1';
+      const authenticatedUserId = '2';
+      const userToDelete = {
+        id: '1',
+        first_name: 'John',
+        last_name: 'Doe',
+        email: 'test@example.com',
+        password: 'hashedpassword',
+        is_active: true,
+        attempts_left: 3,
+        time_left: 60,
+      };
+
+      mockUserRepository.findOne.mockResolvedValueOnce(userToDelete);
+
+      await expect(service.softDeleteUser(userId, authenticatedUserId)).rejects.toHaveProperty(
+        'response',
+        'You are not authorized to delete this user'
+      );
+      expect(mockUserRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+        relations: ['profile', 'organisationMembers', 'created_organisations', 'owned_organisations'],
+      });
+      expect(mockUserRepository.softDelete).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -143,7 +143,7 @@ export class UserController {
   @ApiResponse({ status: 400, description: 'Bad Request' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 500, description: 'Internal Server Error' })
-  async softDeleteUser(@Param('userId') userId: string, @Req() req) {
+  async softDeleteUser(@Param('userId', ParseUUIDPipe) userId: string, @Req() req) {
     const authenticatedUserId = req['user'].id;
 
     return this.userService.softDeleteUser(userId, authenticatedUserId);

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -1,4 +1,16 @@
-import { Body, Controller, Get, Param, ParseUUIDPipe, Patch, Query, Req, Request, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Query,
+  Req,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiForbiddenResponse,
@@ -122,5 +134,18 @@ export class UserController {
   @UseGuards(SuperAdminGuard)
   async updateUserStatus(@Param('userId', ParseUUIDPipe) userId: string, @Body() { status }: UpdateUserStatusDto) {
     return this.userService.updateUserStatus(userId, status);
+  }
+
+  @Delete(':userId')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Soft delete a user account' })
+  @ApiResponse({ status: 204, description: 'Deletion in progress' })
+  @ApiResponse({ status: 400, description: 'Bad Request' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 500, description: 'Internal Server Error' })
+  async softDeleteUser(@Param('userId') userId: string, @Req() req) {
+    const authenticatedUserId = req['user'].id;
+
+    return this.userService.softDeleteUser(userId, authenticatedUserId);
   }
 }

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -225,12 +225,9 @@ export default class UserService {
   }
 
   async softDeleteUser(userId: string, authenticatedUserId: string): Promise<any> {
-    const identifierOptions: UserIdentifierOptionsType = {
-      identifier: userId,
-      identifierType: 'id',
-    };
-
-    const user = await this.getUserRecord(identifierOptions);
+    const user = await this.userRepository.findOne({
+      where: { id: userId },
+    });
 
     if (!user) {
       throw new CustomHttpException('User not found', HttpStatus.NOT_FOUND);


### PR DESCRIPTION
closes #167 
**What does this PR do?**

This PR introduces an endpoint that enables the soft deletion of users from the system. The endpoint will mark a user as inactive instead of permanently deleting them, allowing for the recovery of the user’s data if needed.

**How to Test**

1. **Soft Delete a User**:
   - Use the endpoint `DELETE /api/v1/users/:user_id` to soft delete a user by their user ID.
   
2. **Verify Soft Deletion**:
   - Check if the user’ is deleted from db.
   - Ensure that the user is no longer retrievable through the regular user retrieval endpoints.

**Edge Cases**

- Test whether the user exists before attempting to soft delete.
- Test whether the user has already been soft deleted.
- Test the behavior of the system when trying to soft delete a user that does not exist.

**Checklist**

- Implementing the `/api/v1/users/:user_id` endpoint for soft deletion.
- Validating the `user_id` parameter to ensure it refers to an existing user.
- using ths softdelete type orm method to delete the user.
- Writing tests to validate the soft deletion functionality and edge cases.

**Responses**

- **Successful Response**:
    ```json
   {
        "status_code": 200,
        "status": "success",
        "message": "Deletion in progress"
   }
    ```

- **Error Response when the user does not exist**:
    ```json
    {
        "message": "User not found",
        "status_code": 404
    }
    ```
