### PR TITLE
feat: get product stock

### DIFF
--- a/src/modules/products/products.controller.ts
+++ b/src/modules/products/products.controller.ts
@@ -4,7 +4,6 @@ import { OwnershipGuard } from '../../guards/authorization.guard';
 import { CreateProductRequestDto } from './dto/create-product.dto';
 import { ProductsService } from './products.service';
 import { UpdateProductDTO } from './dto/update-product.dto';
-import { OrganisationGuard } from '../../guards/organisation.guard';
 
 @ApiTags('Products')
 @Controller('/organizations/:id/products')
@@ -83,7 +82,7 @@ export class ProductsController {
     return this.productsService.deleteProduct(id, productId);
   }
 
-  @UseGuards(OrganisationGuard)
+  @UseGuards(OwnershipGuard)
   @Get(':productId/stock')
   @ApiOperation({ summary: 'Gets a product stock details by id' })
   @ApiParam({ name: 'id', description: 'Organization ID', example: '12345' })
@@ -92,6 +91,6 @@ export class ProductsController {
   @ApiResponse({ status: 404, description: 'Product not found' })
   @ApiResponse({ status: 500, description: 'Internal server error' })
   async getProductStock(@Param('productId') productId: string) {
-    return this.getProductStock(productId);
+    return this.productsService.getProductStock(productId);
   }
 }

--- a/src/modules/products/products.controller.ts
+++ b/src/modules/products/products.controller.ts
@@ -4,6 +4,7 @@ import { OwnershipGuard } from '../../guards/authorization.guard';
 import { CreateProductRequestDto } from './dto/create-product.dto';
 import { ProductsService } from './products.service';
 import { UpdateProductDTO } from './dto/update-product.dto';
+import { OrganisationGuard } from '../../guards/organisation.guard';
 
 @ApiTags('Products')
 @Controller('/organizations/:id/products')
@@ -80,5 +81,17 @@ export class ProductsController {
   @ApiResponse({ status: 500, description: 'Internal server error' })
   async deleteProduct(@Param('id') id: string, @Param('productId') productId: string) {
     return this.productsService.deleteProduct(id, productId);
+  }
+
+  @UseGuards(OrganisationGuard)
+  @Get(':productId/stock')
+  @ApiOperation({ summary: 'Gets a product stock details by id' })
+  @ApiParam({ name: 'id', description: 'Organization ID', example: '12345' })
+  @ApiParam({ name: 'productId', description: 'Product ID' })
+  @ApiResponse({ status: 200, description: 'Product stock retrieved successfully' })
+  @ApiResponse({ status: 404, description: 'Product not found' })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  async getProductStock(@Param('productId') productId: string) {
+    return this.getProductStock(productId);
   }
 }

--- a/src/modules/products/products.module.ts
+++ b/src/modules/products/products.module.ts
@@ -6,11 +6,10 @@ import { Product } from './entities/product.entity';
 import { Organisation } from '../organisations/entities/organisations.entity';
 import { ProductVariant } from './entities/product-variant.entity';
 import { User } from '../user/entities/user.entity';
-import { OrganisationMember } from '../organisations/entities/org-members.entity';
 
 @Module({
   controllers: [ProductsController],
   providers: [ProductsService],
-  imports: [TypeOrmModule.forFeature([Product, Organisation, ProductVariant, User, OrganisationMember])],
+  imports: [TypeOrmModule.forFeature([Product, Organisation, ProductVariant, User])],
 })
 export class ProductsModule {}

--- a/src/modules/products/products.module.ts
+++ b/src/modules/products/products.module.ts
@@ -5,10 +5,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Product } from './entities/product.entity';
 import { Organisation } from '../organisations/entities/organisations.entity';
 import { ProductVariant } from './entities/product-variant.entity';
+import { User } from '../user/entities/user.entity';
+import { OrganisationMember } from '../organisations/entities/org-members.entity';
 
 @Module({
   controllers: [ProductsController],
   providers: [ProductsService],
-  imports: [TypeOrmModule.forFeature([Product, Organisation, ProductVariant])],
+  imports: [TypeOrmModule.forFeature([Product, Organisation, ProductVariant, User, OrganisationMember])],
 })
 export class ProductsModule {}

--- a/src/modules/products/products.module.ts
+++ b/src/modules/products/products.module.ts
@@ -5,11 +5,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Product } from './entities/product.entity';
 import { Organisation } from '../organisations/entities/organisations.entity';
 import { ProductVariant } from './entities/product-variant.entity';
-import { User } from '../user/entities/user.entity';
 
 @Module({
   controllers: [ProductsController],
   providers: [ProductsService],
-  imports: [TypeOrmModule.forFeature([Product, Organisation, ProductVariant, User])],
+  imports: [TypeOrmModule.forFeature([Product, Organisation, ProductVariant])],
 })
 export class ProductsModule {}

--- a/src/modules/products/products.service.ts
+++ b/src/modules/products/products.service.ts
@@ -14,6 +14,7 @@ import { Organisation } from '../organisations/entities/organisations.entity';
 import { CreateProductRequestDto } from './dto/create-product.dto';
 import { UpdateProductDTO } from './dto/update-product.dto';
 import { ProductVariant } from './entities/product-variant.entity';
+import { last } from 'rxjs';
 
 interface SearchCriteria {
   name?: string;
@@ -201,5 +202,27 @@ export class ProductsService {
       message: 'Product successfully deleted',
       data: {},
     };
+  }
+
+  async getProductStock(productId: string) {
+    try {
+      const product = await this.productRepository.findOne({ where: { id: productId } });
+      if (!product) {
+        throw new NotFoundException(`Product not found`);
+      }
+      return {
+        message: 'Product stock retrieved successfully',
+        data: {
+          product_id: product.id,
+          current_stock: product.quantity,
+          last_updated: product.updated_at,
+        },
+      };
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      throw new InternalServerErrorException(`Internal error occurred: ${error.message}`);
+    }
   }
 }

--- a/src/modules/products/products.service.ts
+++ b/src/modules/products/products.service.ts
@@ -14,7 +14,6 @@ import { Organisation } from '../organisations/entities/organisations.entity';
 import { CreateProductRequestDto } from './dto/create-product.dto';
 import { UpdateProductDTO } from './dto/update-product.dto';
 import { ProductVariant } from './entities/product-variant.entity';
-import { last } from 'rxjs';
 
 interface SearchCriteria {
   name?: string;

--- a/src/modules/products/products.service.ts
+++ b/src/modules/products/products.service.ts
@@ -204,24 +204,17 @@ export class ProductsService {
   }
 
   async getProductStock(productId: string) {
-    try {
-      const product = await this.productRepository.findOne({ where: { id: productId } });
-      if (!product) {
-        throw new NotFoundException(`Product not found`);
-      }
-      return {
-        message: 'Product stock retrieved successfully',
-        data: {
-          product_id: product.id,
-          current_stock: product.quantity,
-          last_updated: product.updated_at,
-        },
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
-        throw error;
-      }
-      throw new InternalServerErrorException(`Internal error occurred: ${error.message}`);
+    const product = await this.productRepository.findOne({ where: { id: productId } });
+    if (!product) {
+      throw new NotFoundException(`Product not found`);
     }
+    return {
+      message: 'Product stock retrieved successfully',
+      data: {
+        product_id: product.id,
+        current_stock: product.quantity,
+        last_updated: product.updated_at,
+      },
+    };
   }
 }

--- a/src/modules/products/tests/products.service.spec.ts
+++ b/src/modules/products/tests/products.service.spec.ts
@@ -176,4 +176,47 @@ describe('ProductsService', () => {
       expect(deletedProductMock.is_deleted).toBe(true);
     });
   });
+
+  describe('getProductStock', () => {
+    it('should return product stock details if the product is found', async () => {
+      const productId = '123';
+      const productMock = {
+        id: productId,
+        quantity: 20,
+        updated_at: new Date(),
+      };
+
+      jest.spyOn(productRepository, 'findOne').mockResolvedValue(productMock as any);
+
+      const result = await service.getProductStock(productId);
+
+      expect(result).toEqual({
+        message: 'Product stock retrieved successfully',
+        data: {
+          product_id: productMock.id,
+          current_stock: productMock.quantity,
+          last_updated: productMock.updated_at,
+        },
+      });
+    });
+
+    it('should throw NotFoundException if the product is not found', async () => {
+      const productId = 'nonexistent';
+
+      jest.spyOn(productRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(service.getProductStock(productId)).rejects.toThrow(new NotFoundException('Product not found'));
+    });
+
+    it('should throw InternalServerErrorException if an unexpected error occurs', async () => {
+      const productId = '123';
+      const errorMessage = 'Unexpected error';
+
+      jest.spyOn(productRepository, 'findOne').mockRejectedValue(new Error(errorMessage));
+
+      await expect(service.getProductStock(productId)).rejects.toThrow(
+        new InternalServerErrorException(`Internal error occurred: ${errorMessage}`)
+      );
+    });
+  });
 });

--- a/src/modules/products/tests/products.service.spec.ts
+++ b/src/modules/products/tests/products.service.spec.ts
@@ -207,16 +207,5 @@ describe('ProductsService', () => {
 
       await expect(service.getProductStock(productId)).rejects.toThrow(new NotFoundException('Product not found'));
     });
-
-    it('should throw InternalServerErrorException if an unexpected error occurs', async () => {
-      const productId = '123';
-      const errorMessage = 'Unexpected error';
-
-      jest.spyOn(productRepository, 'findOne').mockRejectedValue(new Error(errorMessage));
-
-      await expect(service.getProductStock(productId)).rejects.toThrow(
-        new InternalServerErrorException(`Internal error occurred: ${errorMessage}`)
-      );
-    });
   });
 });


### PR DESCRIPTION
## What does this PR do?
This PR implements an endpoint for fetching the current stock of a product

## How can this pull request be manually tested?
An authenticated user who is a member, owner or creator of the organisation specified by id  can send a `GET` request to `/api/v1/organizations/{org_id}/product/{product_id}/stock`

- On success:
```bash

       "status_code": 200,
       "message": "Product stock retrieved successfully",
       "data": {
           "product_id": "8yf55648-1a26-4ab0-8941-a7843db1e1bc",
           "current_stock: 10,
           "last_updated": "2024-07-29T22:59:10.052Z",
         }
   }
```

## Tasks done
- [x] Implemented GET `/api/v1/organizations/{org_id}/product/{product_id}/stock` to retrieve the current product's stock
- [x] Return 200 OK with the product's stock on successful retrieval.
- [x] Return 404 Not Found if the product does not exist.
- [x] Test endpoint functionality to ensure it correctly handles various scenarios.
- [x] Update API documentation to reflect the new endpoint.


Find the link to the issue [here](https://github.com/hngprojects/hng_boilerplate_nestjs/issues/284)