### PR TITLE
feat: export organization members

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "bull": "^4.16.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "csv-writer": "^1.6.0",
     "google-auth-library": "^9.13.0",
     "date-fns": "^3.6.0",
     "handlebars": "^4.7.8",

--- a/src/modules/organisations/organisations.controller.ts
+++ b/src/modules/organisations/organisations.controller.ts
@@ -185,6 +185,29 @@ export class OrganisationsController {
   }
 
   @ApiOperation({ summary: 'Export members of an Organisation to a CSV file' })
+  @ApiResponse({
+    status: 200,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The CSV file containing organisation members is returned.',
+    headers: {
+      'Content-Type': {
+        description: 'The content type of the response, which is text/csv.',
+        schema: {
+          type: 'string',
+          example: 'text/csv',
+        },
+      },
+      'Content-Disposition': {
+        description: 'Indicates that the content is an attachment with a filename.',
+        schema: {
+          type: 'string',
+          example: 'attachment; filename="organisation-members-{orgId}.csv"',
+        },
+      },
+    },
+  })
   @UseGuards(OwnershipGuard)
   @Get(':org_id/members/export')
   async exportOrganisationMembers(@Param('org_id') orgId: string, @Req() req: Request, @Res() res: Response) {

--- a/src/modules/organisations/organisations.controller.ts
+++ b/src/modules/organisations/organisations.controller.ts
@@ -29,6 +29,7 @@ import { UserOrganizationErrorResponseDto, UserOrganizationResponseDto } from '.
 import { AddMemberDto } from './dto/add-member.dto';
 import { Response } from 'express';
 import { createReadStream, unlink } from 'fs';
+
 @ApiBearerAuth()
 @ApiTags('organization')
 @Controller('organizations')

--- a/src/modules/organisations/organisations.controller.ts
+++ b/src/modules/organisations/organisations.controller.ts
@@ -185,6 +185,7 @@ export class OrganisationsController {
   }
 
   @ApiOperation({ summary: 'Export members of an Organisation to a CSV file' })
+  @UseGuards(OwnershipGuard)
   @Get(':org_id/members/export')
   async exportOrganisationMembers(@Param('org_id') orgId: string, @Req() req: Request, @Res() res: Response) {
     const userId = req['user'].id;

--- a/src/modules/organisations/tests/organisations.service.spec.ts
+++ b/src/modules/organisations/tests/organisations.service.spec.ts
@@ -32,6 +32,11 @@ import { OrganisationMember } from '../entities/org-members.entity';
 import * as SYS_MSG from '../../../helpers/SystemMessages';
 import { CustomHttpException } from '../../../helpers/custom-http-filter';
 import { ORG_MEMBER_DOES_NOT_BELONG, ORG_MEMBER_NOT_FOUND, ROLE_NOT_FOUND } from '../../../helpers/SystemMessages';
+import * as fs from 'fs';
+import * as path from 'path';
+import { createObjectCsvStringifier } from 'csv-writer';
+
+jest.mock('fs');
 
 describe('OrganisationsService', () => {
   let service: OrganisationsService;
@@ -475,6 +480,68 @@ describe('OrganisationsService', () => {
       expect(res.data).toHaveProperty('member_organisations');
       expect(res.data.member_organisations[0]).toHaveProperty('role');
       expect(res.data.member_organisations[0]).toHaveProperty('organisation');
+    });
+  });
+
+  describe('exportOrganisationMembers', () => {
+    const orgId = 'orgId';
+    const userId = 'userId';
+    const basePath = path.resolve(__dirname, '../');
+    const filePath = path.join(basePath, `organisation-members-${orgId}.csv`);
+    afterEach(() => {
+      if (fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath);
+      }
+    });
+    it('should generate a CSV file and call fs.writeFileSync', async () => {
+      const membersResponse = {
+        status_code: 200,
+        message: 'Members retrieved successfully',
+        data: [
+          { id: '1', name: 'John Doe', email: 'john.doe@example.com', role: 'Admin' },
+          { id: '2', name: 'Jane Smith', email: 'jane.smith@example.com', role: 'Member' },
+        ],
+      };
+
+      jest.spyOn(service, 'getOrganisationMembers').mockResolvedValue(membersResponse);
+
+      const csvStringifier = createObjectCsvStringifier({
+        header: [
+          { id: 'id', title: 'ID' },
+          { id: 'name', title: 'Name' },
+          { id: 'email', title: 'Email' },
+          { id: 'role', title: 'Role' },
+        ],
+      });
+
+      const csvData = csvStringifier.getHeaderString() + csvStringifier.stringifyRecords(membersResponse.data);
+
+      jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+
+      await service.exportOrganisationMembers(orgId, userId);
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(filePath, csvData);
+    });
+
+    it('should return the correct file path', async () => {
+      const orgId = 'orgId';
+      const userId = 'userId';
+      const membersResponse = {
+        status_code: 200,
+        message: 'Members retrieved successfully',
+        data: [
+          { id: '1', name: 'John Doe', email: 'john.doe@example.com', role: 'Admin' },
+          { id: '2', name: 'Jane Smith', email: 'jane.smith@example.com', role: 'Member' },
+        ],
+      };
+
+      jest.spyOn(service, 'getOrganisationMembers').mockResolvedValue(membersResponse);
+
+      const basePath = path.resolve(__dirname, '../');
+      const filePath = path.join(basePath, `organisation-members-${orgId}.csv`);
+      const result = await service.exportOrganisationMembers(orgId, userId);
+
+      expect(result).toBe(filePath);
     });
   });
 });


### PR DESCRIPTION
**What does this PR do?**

This PR introduces an endpoint that enables the export of organisation members to a CSV file. The endpoint will generate a CSV file containing details of all members in an organisation, including their ID, name, email, and role.

**How to Test**

**Export Organisation Members to CSV:**

- Use the endpoint `GET /api/v1/organisations/:org_id/members/export` to export members of an organisation by their organisation ID.

**Verify CSV Export:**

- Check if the CSV file is created with the expected headers (ID, Name, Email, Role) and member data.
- Ensure that the file is downloadable and the data matches the organisation members' details in the database.

**Edge Cases**

- Test whether the organisation exists before attempting to export members.
- Test the behaviour of the system when trying to export members from an organisation that does not exist.
- Test the export functionality for an organisation with no members.

**Checklist**

- Implementing the `/api/v1/organisations/:org_id/members/export` endpoint for exporting members to a CSV file.
- Validating the `org_id` parameter to ensure it refers to an existing organisation.
- Using the `csv-writer` module to generate the CSV file.
- Writing tests to validate the CSV export functionality and edge cases.
