### PR TITLE
fix: get all users 

### DIFF
--- a/src/modules/user/tests/user.service.spec.ts
+++ b/src/modules/user/tests/user.service.spec.ts
@@ -386,11 +386,6 @@ describe('UserService', () => {
       });
     });
 
-    it('should throw ForbiddenException when called by non-super admin', async () => {
-      await expect(service.getUsersByAdmin(page, limit, regularUserPayload)).rejects.toThrow(ForbiddenException);
-      expect(mockUserRepository.findAndCount).not.toHaveBeenCalled();
-    });
-
     it('should handle pagination correctly', async () => {
       const users = Array(15)
         .fill(null)

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -1,9 +1,10 @@
-import { Body, Controller, Get, Param, Patch, Query, Req, Request } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Query, Req, Request, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { DeactivateAccountDto } from './dto/deactivate-account.dto';
 import { UpdateUserDto } from './dto/update-user-dto';
 import { UserPayload } from './interfaces/user-payload.interface';
 import UserService from './user.service';
+import { SuperAdminGuard } from '../../guards/super-admin.guard';
 
 @ApiBearerAuth()
 @ApiTags('Users')
@@ -50,6 +51,7 @@ export class UserController {
     return this.userService.getUserDataWithoutPasswordById(id);
   }
 
+  @UseGuards(SuperAdminGuard)
   @Get()
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get all users (Super Admin only)' })

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -194,14 +194,6 @@ export default class UserService {
   }
 
   async getUsersByAdmin(page: number = 1, limit: number = 10, currentUser: UserPayload): Promise<any> {
-    if (currentUser.user_type !== UserType.SUPER_ADMIN) {
-      throw new ForbiddenException({
-        error: 'Forbidden',
-        message: 'Only super admins can access this endpoint',
-        status_code: HttpStatus.FORBIDDEN,
-      });
-    }
-
     const [users, total] = await this.userRepository.findAndCount({
       select: ['id', 'first_name', 'last_name', 'email', 'phone', 'is_active', 'created_at'],
       skip: (page - 1) * limit,


### PR DESCRIPTION

**What is this PR solving?**
- A superadmin can't get the list of all users do to this block of code.
![Screenshot 2024-08-06 at 6 50 31 PM](https://github.com/user-attachments/assets/0d32d942-2ee6-4f8d-8d70-d12ebe4356ea)
- As a result the end point returns a 403 status code
![Screenshot 2024-08-06 at 6 49 18 PM](https://github.com/user-attachments/assets/73963179-4a1f-4ac9-9166-ca509948fc07)


**What did I do in this PR:**
-  Added the super admin guard to the get-all users controller
- Removed the code block that was checking for the user role, as the guard takes care of that
- Updated the service spec file to adjust to these new changes


***Screenshot testing the endpoint after the changes (with a user that is a super-admin):***
![Screenshot 2024-08-06 at 6 52 27 PM](https://github.com/user-attachments/assets/5a797336-efe3-4acf-9917-f642faf7659c)

***Screenshot testing the endpoint after the changes (with a user that is NOT a super-admin):***
![Screenshot 2024-08-06 at 6 54 27 PM](https://github.com/user-attachments/assets/d58c68b8-04a6-4852-9a17-397561623584)

**How to test this PR?**
1- Login with a account that has super admin role
2- Fetch the endpoint ```GET /api/v1/users```


Reference Issue 651: [Link to Issue](https://github.com/hngprojects/hng_boilerplate_nestjs/pull/651)