### PR TITLE
feat: creating the member guard

### DIFF
--- a/src/guards/member.guard.ts
+++ b/src/guards/member.guard.ts
@@ -1,0 +1,56 @@
+import { Injectable, CanActivate, ExecutionContext, HttpStatus } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+import * as SYS_MSG from '../helpers/SystemMessages';
+import { Organisation } from './../modules/organisations/entities/organisations.entity';
+import { CustomHttpException } from '../helpers/custom-http-filter';
+import { OrganisationMember } from '../modules/organisations/entities/org-members.entity';
+import { PermissionCategory } from '../modules/organisation-permissions/helpers/PermissionCategory';
+import { PERMISSIONS_KEY } from './permission.decorator';
+
+@Injectable()
+export class MembershipGuard implements CanActivate {
+  constructor(
+    private reflector: Reflector,
+    @InjectRepository(Organisation)
+    private readonly organisationRepository: Repository<Organisation>,
+    @InjectRepository(OrganisationMember)
+    private readonly membersRepository: Repository<OrganisationMember>
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const currentUserId = request.user.sub;
+    const organisationId = request.params.org_id;
+    const requiredPermissions = this.reflector.getAllAndOverride<PermissionCategory[]>(PERMISSIONS_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    const organisation = await this.organisationRepository.findOne({
+      where: { id: organisationId },
+      relations: ['owner', 'creator', 'organisationMembers', 'organisationMembers.user_id'],
+    });
+
+    if (!organisation) {
+      throw new CustomHttpException(SYS_MSG.ORG_NOT_FOUND, HttpStatus.NOT_FOUND);
+    }
+
+    if (organisation.owner.id === currentUserId || organisation.creator.id === currentUserId) return true;
+    const roles = await this.membersRepository.findOne({
+      where: { user_id: currentUserId },
+      relations: { role: true, organisation_id: true, user_id: true },
+    });
+
+    const userHasPerms = roles.role.permissions.some(permission => {
+      return requiredPermissions.includes(permission.category);
+    });
+
+    if (userHasPerms) {
+      return true;
+    } else {
+      throw new CustomHttpException(SYS_MSG.FORBIDDEN_ACTION, HttpStatus.FORBIDDEN);
+    }
+  }
+}

--- a/src/guards/permission.decorator.ts
+++ b/src/guards/permission.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+import { PermissionCategory } from 'src/modules/organisation-permissions/helpers/PermissionCategory';
+export const PERMISSIONS_KEY = 'permissions';
+export const Permissions = (...permissions: PermissionCategory[]) => SetMetadata(PERMISSIONS_KEY, permissions);

--- a/src/modules/organisation-permissions/entities/permissions.entity.ts
+++ b/src/modules/organisation-permissions/entities/permissions.entity.ts
@@ -1,11 +1,16 @@
 import { Entity, Column, ManyToOne } from 'typeorm';
 import { AbstractBaseEntity } from '../../../entities/base.entity';
 import { OrganisationRole } from '../../organisation-role/entities/organisation-role.entity';
+import { PermissionCategory } from '../helpers/PermissionCategory';
 
 @Entity()
 export class Permissions extends AbstractBaseEntity {
-  @Column({ type: 'text' })
-  category: string;
+  @Column({
+    type: 'enum',
+    enum: PermissionCategory,
+    unique: true,
+  })
+  category: PermissionCategory;
 
   @Column({ type: 'boolean', nullable: false })
   permission_list: boolean;

--- a/src/modules/organisation-permissions/organisation-permissions.service.ts
+++ b/src/modules/organisation-permissions/organisation-permissions.service.ts
@@ -5,6 +5,7 @@ import { OrganisationRole } from '../organisation-role/entities/organisation-rol
 import { Organisation } from '../organisations/entities/organisations.entity';
 import { UpdatePermissionDto } from './dto/update-permission.dto';
 import { Permissions } from './entities/permissions.entity';
+import { PermissionCategory } from './helpers/PermissionCategory';
 
 @Injectable()
 export class OrganisationPermissionsService {
@@ -56,8 +57,13 @@ export class OrganisationPermissionsService {
         throw new NotFoundException(`Permission not found in the specified role`);
       }
 
+      const permissionCategory = category as PermissionCategory;
+
       updatePromises.push(
-        this.permissionRepository.update({ role: { id: roleId }, category }, { permission_list: value })
+        this.permissionRepository.update(
+          { role: { id: roleId }, category: permissionCategory },
+          { permission_list: value }
+        )
       );
     }
 


### PR DESCRIPTION
## What does this PR do?
This PR has the member guard which checks if the user is the owner/creator or if they have the necessary permissions to perform an operation

## How Can This Be Tested?
- add it to an endpoint that requires this validation. For example,
```
@UseGuard(MembershipGuard)
@Permissions(PermissionCategory.CanAddProducts)
@Post('/products')
async createProduct(){}
```

## Responses
### Successful
If the user has the necessary permissions, they are allowed to proceed with the operation

### Errors
- Organisation does not exist
```
{
  message: "Organisation not found",
  status: 404
}
```

- User does not have the necessary permissions
```
{
  "message": "You dont have the permission to perform this action",
  "status": 403
}
```

### Tasks
- [x] Created a guard 
- [x] Validate that the organisation exists
- [x] Created a permissions decorator that can be used to specify a list of permissions
- [x] Validate that the user has the necessary permissions to perform an operation

## Reference Issue
[Link to Issue on Linear](https://linear.app/team-bingo/issue/BAC2-192/create-member-guard)