### PR TITLE
feat: remove member from organisation

### DIFF
--- a/src/helpers/http-exception-filter.ts
+++ b/src/helpers/http-exception-filter.ts
@@ -1,0 +1,43 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { Response } from 'express';
+
+export interface ExceptionResponse {
+  statusCode: number;
+  message: string | string[];
+  error: string;
+}
+
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const status = exception instanceof HttpException ? exception.getStatus() : HttpStatus.INTERNAL_SERVER_ERROR;
+
+    const exceptionResponse =
+      exception instanceof HttpException
+        ? exception.getResponse()
+        : {
+            message: (exception as InternalServerErrorException).message || 'Internal server error',
+            error: 'Internal Server Error',
+          };
+
+    const errorMessage =
+      typeof exceptionResponse === 'string' ? exceptionResponse : (exceptionResponse as ExceptionResponse).message;
+
+    const error = typeof exceptionResponse === 'string' ? '' : (exceptionResponse as ExceptionResponse).error;
+
+    response.status(status).json({
+      status,
+      error: error,
+      message: errorMessage,
+    });
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,6 @@ import { AppModule } from './app.module';
 import { initializeDataSource } from './database/data-source';
 import { SeedingService } from './database/seeding/seeding.service';
 import { ResponseInterceptor } from './shared/inteceptors/response.interceptor';
-import { HttpExceptionFilter } from './helpers/http-exception-filter';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, { bufferLogs: true });
@@ -33,8 +32,6 @@ async function bootstrap() {
   app.enableCors();
   app.setGlobalPrefix('api/v1', { exclude: ['/', 'health', 'api', 'api/v1', 'api/docs', 'probe'] });
   app.useGlobalInterceptors(new ResponseInterceptor());
-  // Apply the global exception filter
-  app.useGlobalFilters(new HttpExceptionFilter());
 
   const options = new DocumentBuilder()
     .setTitle('HNG Boilerplate')

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { AppModule } from './app.module';
 import { initializeDataSource } from './database/data-source';
 import { SeedingService } from './database/seeding/seeding.service';
 import { ResponseInterceptor } from './shared/inteceptors/response.interceptor';
+import { HttpExceptionFilter } from './helpers/http-exception-filter';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, { bufferLogs: true });
@@ -32,6 +33,8 @@ async function bootstrap() {
   app.enableCors();
   app.setGlobalPrefix('api/v1', { exclude: ['/', 'health', 'api', 'api/v1', 'api/docs', 'probe'] });
   app.useGlobalInterceptors(new ResponseInterceptor());
+  // Apply the global exception filter
+  app.useGlobalFilters(new HttpExceptionFilter());
 
   const options = new DocumentBuilder()
     .setTitle('HNG Boilerplate')

--- a/src/modules/organisations/dto/org-member.dto.ts
+++ b/src/modules/organisations/dto/org-member.dto.ts
@@ -2,10 +2,8 @@ import { IsUUID, IsNotEmpty } from 'class-validator';
 
 export class RemoveOrganisationMemberDto {
   @IsUUID()
-  // @IsNotEmpty()
   userId?: string;
 
   @IsUUID()
-  // @IsNotEmpty()
   organisationId?: string;
 }

--- a/src/modules/organisations/dto/org-member.dto.ts
+++ b/src/modules/organisations/dto/org-member.dto.ts
@@ -1,0 +1,11 @@
+import { IsUUID, IsNotEmpty } from 'class-validator';
+
+export class RemoveOrganisationMemberDto {
+  @IsUUID()
+  // @IsNotEmpty()
+  userId?: string;
+
+  @IsUUID()
+  // @IsNotEmpty()
+  organisationId?: string;
+}

--- a/src/modules/organisations/entities/org-members.entity.ts
+++ b/src/modules/organisations/entities/org-members.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToOne } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToOne, JoinColumn, DeleteDateColumn } from 'typeorm';
 import { AbstractBaseEntity } from './../../../entities/base.entity';
 import { User } from '../../user/entities/user.entity';
 import { Organisation } from './organisations.entity';
@@ -8,14 +8,21 @@ import { OrganisationRole } from '../../organisation-role/entities/organisation-
 @Entity()
 export class OrganisationMember extends AbstractBaseEntity {
   @ManyToOne(() => User, user => user.organisationMembers)
+  @JoinColumn({ name: 'user_id' })
   user_id: User;
 
   @ManyToOne(() => Organisation, organisation => organisation.organisationMembers)
+  @JoinColumn({ name: 'organisation_id' })
   organisation_id: Organisation;
 
   @ManyToOne(() => OrganisationRole, role => role.organisationMembers)
+  @JoinColumn({ name: 'role_id' })
   role: OrganisationRole;
 
   @ManyToOne(() => Profile)
+  @JoinColumn({ name: 'profile_id' })
   profile_id: Profile;
+
+  @DeleteDateColumn()
+  deletedAt?: Date;
 }

--- a/src/modules/organisations/organisations.controller.ts
+++ b/src/modules/organisations/organisations.controller.ts
@@ -13,12 +13,13 @@ import {
   Res,
   UseGuards,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { OwnershipGuard } from '../../guards/authorization.guard';
 import { OrganisationMembersResponseDto } from './dto/org-members-response.dto';
 import { OrganisationRequestDto } from './dto/organisation.dto';
 import { UpdateOrganisationDto } from './dto/update-organisation.dto';
 import { OrganisationsService } from './organisations.service';
+import { RemoveOrganisationMemberDto } from './dto/org-member.dto';
 
 @ApiBearerAuth()
 @ApiTags('organization')
@@ -83,5 +84,17 @@ export class OrganisationsController {
   ): Promise<OrganisationMembersResponseDto> {
     const { sub } = req.user;
     return this.organisationsService.getOrganisationMembers(org_id, page, page_size, sub);
+  }
+
+  @UseGuards(OwnershipGuard)
+  @Delete('/organisatonId/members/:userId')
+  @ApiOperation({ summary: 'Gets a product by id' })
+  @ApiParam({ name: 'id', description: 'Organization ID', example: '12345' })
+  @ApiResponse({ status: 200, description: 'Member removed successfully' })
+  @ApiResponse({ status: 400, description: 'Bad request' })
+  @ApiResponse({ status: 404, description: 'Product not found' })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  async removeOrganisationMember(@Param() params: RemoveOrganisationMemberDto) {
+    return this.organisationsService.removeOrganisationMember(params);
   }
 }

--- a/src/modules/organisations/organisations.controller.ts
+++ b/src/modules/organisations/organisations.controller.ts
@@ -87,7 +87,7 @@ export class OrganisationsController {
   }
 
   @UseGuards(OwnershipGuard)
-  @Delete('/organisatonId/members/:userId')
+  @Delete(':organizatonId/members/:userId')
   @ApiOperation({ summary: 'Gets a product by id' })
   @ApiParam({ name: 'id', description: 'Organization ID', example: '12345' })
   @ApiResponse({ status: 200, description: 'Member removed successfully' })

--- a/src/modules/organisations/organisations.service.ts
+++ b/src/modules/organisations/organisations.service.ts
@@ -19,6 +19,7 @@ import { CreateOrganisationMapper } from './mapper/create-organisation.mapper';
 import { OrganisationMemberMapper } from './mapper/org-members.mapper';
 import { OrganisationMapper } from './mapper/organisation.mapper';
 import { RemoveOrganisationMemberDto } from './dto/org-member.dto';
+import { CustomHttpException } from '../../helpers/custom-http-filter';
 
 @Injectable()
 export class OrganisationsService {
@@ -125,17 +126,17 @@ export class OrganisationsService {
     }
   }
 
-  async removeOrganisationMember(createOrganisationMemberDto: RemoveOrganisationMemberDto) {
-    const { organisationId, userId } = createOrganisationMemberDto;
+  async removeOrganisationMember(removeOrganisationMemberDto: RemoveOrganisationMemberDto) {
+    const { organisationId, userId } = removeOrganisationMemberDto;
 
     const user = await this.userRepository.findOne({ where: { id: userId } });
     if (!user) {
-      throw new NotFoundException('No user found with the provided id');
+      throw new CustomHttpException('No user found with the provided id', 404);
     }
 
     const org = await this.organisationRepository.findOne({ where: { id: organisationId } });
     if (!org) {
-      throw new NotFoundException('No organisation found with the provided id');
+      throw new CustomHttpException('No organisation found with the provided id', 404);
     }
 
     const orgMember = await this.organisationMemberRepository.findOne({
@@ -145,7 +146,7 @@ export class OrganisationsService {
       },
     });
     if (!orgMember) {
-      throw new NotFoundException('No organisation member found with provided ids');
+      throw new CustomHttpException('No organisation member found with provided ids', 404);
     }
 
     await this.organisationMemberRepository.softDelete(orgMember.id);

--- a/src/modules/organisations/tests/organisations.service.spec.ts
+++ b/src/modules/organisations/tests/organisations.service.spec.ts
@@ -18,6 +18,7 @@ import {
 } from '@nestjs/common';
 import { Profile } from '../../profile/entities/profile.entity';
 import { OrganisationMember } from '../entities/org-members.entity';
+import { CustomHttpException } from '../../../helpers/custom-http-filter';
 
 describe('OrganisationsService', () => {
   let service: OrganisationsService;
@@ -229,7 +230,7 @@ describe('OrganisationsService', () => {
   });
 
   describe('removeOrganisationMember', () => {
-    it('should throw NotFoundException if user is not found', async () => {
+    it('should throw CustomHttpException if user is not found', async () => {
       jest.spyOn(userRepository, 'findOne').mockResolvedValue(null);
 
       await expect(
@@ -237,10 +238,10 @@ describe('OrganisationsService', () => {
           organisationId: 'org-id',
           userId: 'user-id',
         } as any)
-      ).rejects.toThrow(NotFoundException);
+      ).rejects.toThrow(CustomHttpException);
     });
 
-    it('should throw NotFoundException if organisation is not found', async () => {
+    it('should throw CustomHttpException if organisation is not found', async () => {
       const user: any = {
         id: 'some-uuid-here',
         email: 'test@example.com',
@@ -255,10 +256,10 @@ describe('OrganisationsService', () => {
           organisationId: 'org-id',
           userId: 'user-id',
         } as any)
-      ).rejects.toThrow(NotFoundException);
+      ).rejects.toThrow(CustomHttpException);
     });
 
-    it('should throw NotFoundException if organisation member is not found', async () => {
+    it('should throw CustomHttpException if organisation member is not found', async () => {
       const user: any = {
         id: 'some-uuid-here',
         email: 'test@example.com',
@@ -276,7 +277,7 @@ describe('OrganisationsService', () => {
           organisationId: 'org-id',
           userId: 'user-id',
         } as any)
-      ).rejects.toThrow(NotFoundException);
+      ).rejects.toThrow(CustomHttpException);
     });
 
     it('should remove an organisation member successfully', async () => {

--- a/src/modules/organisations/tests/organisations.service.spec.ts
+++ b/src/modules/organisations/tests/organisations.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { OrganisationsService } from '../organisations.service';
-import { Repository } from 'typeorm';
+import { Repository, UpdateResult } from 'typeorm';
 import { User } from '../../user/entities/user.entity';
 import { Organisation } from '../entities/organisations.entity';
 import { getRepositoryToken } from '@nestjs/typeorm';
@@ -44,7 +44,9 @@ describe('OrganisationsService', () => {
         {
           provide: getRepositoryToken(OrganisationMember),
           useValue: {
+            findOne: jest.fn(),
             save: jest.fn(),
+            softDelete: jest.fn(),
           },
         },
         UserService,
@@ -86,14 +88,18 @@ describe('OrganisationsService', () => {
     });
 
     it('should create an organisation', async () => {
-      jest.spyOn(organisationRepository, 'findBy').mockResolvedValue(null);
+      jest.spyOn(organisationRepository, 'findBy').mockResolvedValue([]);
       jest.spyOn(userRepository, 'findOne').mockResolvedValue({
         ...orgMock.owner,
       } as User);
       jest.spyOn(organisationRepository, 'create').mockReturnValue(orgMock);
       jest.spyOn(organisationRepository, 'save').mockResolvedValue({
         ...orgMock,
-      });
+      } as Organisation);
+      jest.spyOn(organisationMemberRepository, 'save').mockResolvedValue({
+        user_id: { id: orgMock.owner.id },
+        organisation_id: orgMock.id,
+      } as any);
 
       const result = await service.create(createMockOrganisationRequestDto(), orgMock.owner.id);
       expect(result.status).toEqual('success');
@@ -115,7 +121,7 @@ describe('OrganisationsService', () => {
       const organisation = new Organisation();
 
       jest.spyOn(organisationRepository, 'findOneBy').mockResolvedValueOnce(organisation);
-      jest.spyOn(organisationRepository, 'update').mockResolvedValueOnce({ affected: 1 } as any);
+      jest.spyOn(organisationRepository, 'update').mockResolvedValueOnce({ affected: 1 } as UpdateResult);
       jest
         .spyOn(organisationRepository, 'findOneBy')
         .mockResolvedValueOnce({ ...organisation, ...updateOrganisationDto });
@@ -219,6 +225,86 @@ describe('OrganisationsService', () => {
       expect(result.data).toEqual([
         { id: 'anotherUserId', name: 'Jane Doe', email: 'jane@email.com', phone_number: '1111' },
       ]);
+    });
+  });
+
+  describe('removeOrganisationMember', () => {
+    it('should throw NotFoundException if user is not found', async () => {
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(
+        service.removeOrganisationMember({
+          organisationId: 'org-id',
+          userId: 'user-id',
+        } as any)
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw NotFoundException if organisation is not found', async () => {
+      const user: any = {
+        id: 'some-uuid-here',
+        email: 'test@example.com',
+        first_name: 'John',
+        last_name: 'Doe',
+      };
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(user);
+      jest.spyOn(organisationRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(
+        service.removeOrganisationMember({
+          organisationId: 'org-id',
+          userId: 'user-id',
+        } as any)
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw NotFoundException if organisation member is not found', async () => {
+      const user: any = {
+        id: 'some-uuid-here',
+        email: 'test@example.com',
+        first_name: 'John',
+        last_name: 'Doe',
+      };
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(user);
+      jest.spyOn(organisationRepository, 'findOne').mockResolvedValue({
+        id: 'org-id',
+        organisationMembers: [],
+      } as Organisation);
+
+      await expect(
+        service.removeOrganisationMember({
+          organisationId: 'org-id',
+          userId: 'user-id',
+        } as any)
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should remove an organisation member successfully', async () => {
+      const user: any = {
+        id: 'some-uuid-here',
+        email: 'test@example.com',
+        first_name: 'John',
+        last_name: 'Doe',
+      };
+
+      const organisation = {
+        id: 'org-id',
+        organisationMembers: [{ user_id: { id: 'user-id' } }],
+      } as any;
+
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(user);
+      jest.spyOn(organisationRepository, 'findOne').mockResolvedValue(organisation);
+      jest.spyOn(organisationMemberRepository, 'findOne').mockResolvedValue(organisation.organisationMembers[0]);
+      jest.spyOn(organisationMemberRepository, 'softDelete').mockResolvedValue({ affected: 1 } as UpdateResult);
+
+      const result = await service.removeOrganisationMember({
+        organisationId: 'org-id',
+        userId: 'user-id',
+      } as any);
+
+      expect(result).toEqual({
+        message: 'Member removed from organisation successfully',
+      });
     });
   });
 });


### PR DESCRIPTION
### What does this PR do

It removes a member from an organisation

### Response:
- On success, the API should return a `204 No Content` status code with the success message.
- On failure, the API should return a 400 Bad Request status code with appropriate error messages.


## Successful Response
```json
{
  "message": "User removed from organisation successfully",
  "status_code": 200
}
```

## Unsuccessful Response
```json
{
  "status": "Bad Request",
  "message": "Bad request error",
  "status_code": 400
}
```


## Unauthenticated Error Message
```json
{
  "status": "Unauthorized",
  "message": "User not authenticated",
  "status_code": 401
}
```

## Unauthorized Error Message
```json
{
  "status": "Forbidden",
  "message": "Only owners can add users",
  "status_code": 403
}
```

## Task 
- [x] Create the endpoint HTTP DELETE `/api/v1/organizations/{orgId}/members/{userId}` to remove a user from an organization.
- [x] Implement authentication middleware to validate JWT tokens.
- [x] Implement an authorization check to ensure that only the organization's owner has the ability to add users.
- [x] Validate the request param {orgId} and {userId}
- [x] Write unit tests for all scenarios, including successful removal of user from organization, validation errors, and authentication/authorization checks.
- [x] Perform security testing to ensure data protection and compliance.

Link to issue #173  
