### PR TITLE
feat: get user testimonials

### DIFF
--- a/src/helpers/SystemMessages.ts
+++ b/src/helpers/SystemMessages.ts
@@ -48,3 +48,5 @@ export const USER_NOT_REGISTERED = 'User not found, register to continue';
 export const INVITE_ACCEPTED = 'Invite already accepted';
 export const INVALID_INVITE = 'Invalid invite link';
 export const INVITE_NOT_FOUND = 'Invite link not found';
+export const NO_USER_TESTIMONIALS = 'User has no testimonials';
+export const USER_TESTIMONIALS_FETCHED = 'User testimonials retrieved successfully';

--- a/src/modules/testimonials/dto/get-testimonials.dto.ts
+++ b/src/modules/testimonials/dto/get-testimonials.dto.ts
@@ -1,0 +1,46 @@
+import { TestimonialData } from '../interfaces/testimonials.interface';
+import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+class DataDto {
+  @ApiProperty({
+    description: "The user's id",
+    example: '1',
+  })
+  @IsString()
+  user_id: string;
+
+  @ApiProperty({
+    description: "The list of the user's testimonials",
+  })
+  testimonials: TestimonialData[];
+}
+
+export class GetTestimonialsResponseDto {
+  @ApiProperty({
+    description: 'Response message',
+    example: 'User testimonials retrieved successfully',
+  })
+  @IsString()
+  message: string;
+
+  @ApiProperty({
+    description: 'The data',
+  })
+  data: DataDto;
+}
+
+export class GetTestimonialsErrorResponseDto {
+  @ApiProperty({
+    description: 'Response message',
+    example: 'User has no testimonials',
+  })
+  @IsString()
+  message: string;
+
+  @ApiProperty({
+    description: 'Response status code',
+    example: '400',
+  })
+  status: number;
+}

--- a/src/modules/testimonials/dto/get-testimonials.dto.ts
+++ b/src/modules/testimonials/dto/get-testimonials.dto.ts
@@ -2,7 +2,7 @@ import { TestimonialData } from '../interfaces/testimonials.interface';
 import { IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
-class DataDto {
+class TestimonialDataDto {
   @ApiProperty({
     description: "The user's id",
     example: '1',
@@ -12,6 +12,12 @@ class DataDto {
 
   @ApiProperty({
     description: "The list of the user's testimonials",
+    example: {
+      id: 'testimonial-id',
+      name: 'Client Name',
+      content: 'Testimonial Content',
+      created_at: new Date(),
+    },
   })
   testimonials: TestimonialData[];
 }
@@ -27,10 +33,10 @@ export class GetTestimonialsResponseDto {
   @ApiProperty({
     description: 'The data',
   })
-  data: DataDto;
+  data: TestimonialDataDto;
 }
 
-export class GetTestimonialsErrorResponseDto {
+export class GetTestimonials400ErrorResponseDto {
   @ApiProperty({
     description: 'Response message',
     example: 'User has no testimonials',
@@ -41,6 +47,21 @@ export class GetTestimonialsErrorResponseDto {
   @ApiProperty({
     description: 'Response status code',
     example: '400',
+  })
+  status: number;
+}
+
+export class GetTestimonials404ErrorResponseDto {
+  @ApiProperty({
+    description: 'Response message',
+    example: 'User not found!',
+  })
+  @IsString()
+  message: string;
+
+  @ApiProperty({
+    description: 'Response status code',
+    example: '404',
   })
   status: number;
 }

--- a/src/modules/testimonials/mappers/testimonial.mapper.ts
+++ b/src/modules/testimonials/mappers/testimonial.mapper.ts
@@ -1,0 +1,14 @@
+import { Testimonial } from '../entities/testimonials.entity';
+
+export class TestimonialMapper {
+  static mapToEntity(testimonial: Testimonial) {
+    if (!testimonial) throw new Error('Testimonial is required');
+
+    return {
+      id: testimonial.id,
+      name: testimonial.name,
+      content: testimonial.content,
+      created_at: testimonial.created_at,
+    };
+  }
+}

--- a/src/modules/testimonials/testimonials.controller.ts
+++ b/src/modules/testimonials/testimonials.controller.ts
@@ -1,10 +1,11 @@
-import { Body, Controller, Post, Req } from '@nestjs/common';
+import { Body, Controller, Post, Req, Get, Param, DefaultValuePipe, Query, ParseIntPipe } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { UserPayload } from '../user/interfaces/user-payload.interface';
 import UserService from '../user/user.service';
 import { CreateTestimonialResponseDto } from './dto/create-testimonial-response.dto';
 import { CreateTestimonialDto } from './dto/create-testimonial.dto';
 import { TestimonialsService } from './testimonials.service';
+import { GetTestimonialsResponseDto, GetTestimonialsErrorResponseDto } from './dto/get-testimonials.dto';
 
 @ApiBearerAuth()
 @ApiTags('Testimonials')
@@ -37,5 +38,30 @@ export class TestimonialsController {
       message: 'Testimonial created successfully',
       data,
     };
+  }
+
+  @ApiOperation({ summary: "Get All User's Testimonials" })
+  @ApiResponse({
+    status: 200,
+    description: 'User testimonials retrieved successfully',
+    type: GetTestimonialsResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'User not found',
+    type: GetTestimonialsErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'User has no testimonials',
+    type: GetTestimonialsErrorResponseDto,
+  })
+  @Get('/:user_id')
+  async getAllTestimonials(
+    @Param('user_id') userId: string,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('page_size', new DefaultValuePipe(1), ParseIntPipe) page_size: number
+  ) {
+    return this.testimonialsService.getAllTestimonials(userId, page, page_size);
   }
 }

--- a/src/modules/testimonials/testimonials.controller.ts
+++ b/src/modules/testimonials/testimonials.controller.ts
@@ -5,7 +5,11 @@ import UserService from '../user/user.service';
 import { CreateTestimonialResponseDto } from './dto/create-testimonial-response.dto';
 import { CreateTestimonialDto } from './dto/create-testimonial.dto';
 import { TestimonialsService } from './testimonials.service';
-import { GetTestimonialsResponseDto, GetTestimonialsErrorResponseDto } from './dto/get-testimonials.dto';
+import {
+  GetTestimonialsResponseDto,
+  GetTestimonials400ErrorResponseDto,
+  GetTestimonials404ErrorResponseDto,
+} from './dto/get-testimonials.dto';
 
 @ApiBearerAuth()
 @ApiTags('Testimonials')
@@ -49,18 +53,18 @@ export class TestimonialsController {
   @ApiResponse({
     status: 404,
     description: 'User not found',
-    type: GetTestimonialsErrorResponseDto,
+    type: GetTestimonials404ErrorResponseDto,
   })
   @ApiResponse({
     status: 400,
     description: 'User has no testimonials',
-    type: GetTestimonialsErrorResponseDto,
+    type: GetTestimonials400ErrorResponseDto,
   })
   @Get('/:user_id')
   async getAllTestimonials(
     @Param('user_id') userId: string,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
-    @Query('page_size', new DefaultValuePipe(1), ParseIntPipe) page_size: number
+    @Query('page_size', new DefaultValuePipe(3), ParseIntPipe) page_size: number
   ) {
     return this.testimonialsService.getAllTestimonials(userId, page, page_size);
   }

--- a/src/modules/testimonials/testimonials.service.ts
+++ b/src/modules/testimonials/testimonials.service.ts
@@ -63,9 +63,6 @@ export class TestimonialsService {
 
     if (!user) throw new CustomHttpException(SYS_MSG.USER_NOT_FOUND, HttpStatus.NOT_FOUND);
 
-    if (!page) page = 1;
-    if (!pageSize) pageSize = 3;
-
     let testimonials = await this.testimonialRepository.find({
       relations: ['user'],
       where: {

--- a/src/modules/testimonials/tests/mocks/testimonials.mock.ts
+++ b/src/modules/testimonials/tests/mocks/testimonials.mock.ts
@@ -1,0 +1,45 @@
+import { Testimonial } from '../../entities/testimonials.entity';
+import { mockUser } from '../../../organisations/tests/mocks/user.mock';
+
+export const testimonialsMock: Testimonial[] = [
+  {
+    id: '1',
+    user: mockUser,
+    name: 'Mary Jane',
+    content: 'Excellent Work!',
+    created_at: new Date(),
+    updated_at: new Date(),
+  },
+  {
+    id: '2',
+    user: mockUser,
+    name: 'Clara James',
+    content: 'Excellent Work! Highly Recommend',
+    created_at: new Date(),
+    updated_at: new Date(),
+  },
+  {
+    id: '3',
+    user: mockUser,
+    name: 'Jamie Waen',
+    content: 'Organized and quality work!',
+    created_at: new Date(),
+    updated_at: new Date(),
+  },
+  {
+    id: '4',
+    user: mockUser,
+    name: 'Joanne',
+    content: 'Excellent Work!',
+    created_at: new Date(),
+    updated_at: new Date(),
+  },
+  {
+    id: '5',
+    user: mockUser,
+    name: 'Mary Jane',
+    content: 'Highly Recommend!',
+    created_at: new Date(),
+    updated_at: new Date(),
+  },
+];


### PR DESCRIPTION
# What does this PR do?
This PR returns the specified user's testimonials

## How Can This Be Manually Tested?
1. Login to an account using the `api/v1/auth/login`
2. Retrieve testimonials using the `/api/v1/testimonials/:user_id`
3. You can also add query parameters for the `page` and `page_size`

## Responses
### Successful
```
{
    "status": 200,
    "message": "User's testimonials successfully retrieved",
    "data": {
          "user_id": "user-123",
          "testimonials": [
              {
                 "id": "testimonial-12",
                 "name": "Jane Doe",
                 "content": "Excellent work!",
                 "created_at": "2024-07-08T23:45:00Z"
              }
         ]
      },
     "pagination": {
          "page": 1,
          "pageSize": 1,
          "total_pages": 1
      }
}
```
![image](https://github.com/user-attachments/assets/61f66404-0b3f-446f-a305-283a9ebf443d)

### Error
```
{
  "status": 400,
  "message": "User has no testimonials"
}
```
![image](https://github.com/user-attachments/assets/a80d16c0-a960-4dc7-b684-a05d9352c025)

## Completed Tasks
- [x] Created a GET endpoint that returns the user's testimonial
- [x] Validated the user
- [x] Validate when a user has no testimonials

## Reference Issue
[Link to Linear Issue](https://linear.app/team-bingo/issue/BAC2-195/retrieve-all-the-users-testimonials)
[Link to GitHub Issue](https://github.com/hngprojects/hng_boilerplate_nestjs/issues/201)