### PR TITLE
fix: bug in create organisation endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1124,37 +1124,6 @@
         "@css-inline/css-inline-win32-x64-msvc": "0.14.1"
       }
     },
-    "node_modules/@css-inline/css-inline-linux-x64-gnu": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@css-inline/css-inline-linux-x64-gnu/-/css-inline-linux-x64-gnu-0.14.1.tgz",
-      "integrity": "sha512-yubbEye+daDY/4vXnyASAxH88s256pPati1DfVoZpU1V0+KP0BZ1dByZOU1ktExurbPH3gZOWisAnBE9xon0Uw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@css-inline/css-inline/node_modules/@css-inline/css-inline-android-arm-eabi": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@css-inline/css-inline-android-arm-eabi/-/css-inline-android-arm-eabi-0.14.1.tgz",
-      "integrity": "sha512-LNUR8TY4ldfYi0mi/d4UNuHJ+3o8yLQH9r2Nt6i4qeg1i7xswfL3n/LDLRXvGjBYqeEYNlhlBQzbPwMX1qrU6A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@css-inline/css-inline-android-arm64": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/@css-inline/css-inline-android-arm64/-/css-inline-android-arm64-0.14.1.tgz",
@@ -1259,7 +1228,6 @@
         "x64"
       ],
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -1294,6 +1262,22 @@
       "optional": true,
       "os": [
         "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@css-inline/css-inline/node_modules/@css-inline/css-inline-android-arm-eabi": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@css-inline/css-inline-android-arm-eabi/-/css-inline-android-arm-eabi-0.14.1.tgz",
+      "integrity": "sha512-LNUR8TY4ldfYi0mi/d4UNuHJ+3o8yLQH9r2Nt6i4qeg1i7xswfL3n/LDLRXvGjBYqeEYNlhlBQzbPwMX1qrU6A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
       ],
       "engines": {
         "node": ">= 10"
@@ -14522,10 +14506,9 @@
       }
     },
     "node_modules/luxon": {
-      "version": "3.4.4",
+      "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
       "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
-      "version": "3.5.0",
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/src/helpers/SystemMessages.ts
+++ b/src/helpers/SystemMessages.ts
@@ -47,6 +47,7 @@ export const PAYMENT_NOTFOUND = 'Payment plan not found';
 export const PRODUCT_NOT_FOUND = 'Product not found!';
 export const COMMENT_CREATED = 'Comment added successfully';
 export const ORG_UPDATE = 'Organisation updated successfully';
+export const ORG_EXISTS = 'Organisation with this email already exists';
 export const ORG_MEMBER_NOT_FOUND = 'Member not found';
 export const ORG_MEMBER_DOES_NOT_BELONG = 'Member does not belong to the specified organisation';
 export const ROLE_NOT_FOUND = 'Role not found in the organization';


### PR DESCRIPTION
# What does this PR do
Implements a fix for the create method in organisation service causing exceptions to be raised within the server rather than being returned to client.

This fix was implemented by using the custom http excption filter and removing the try catch block to allow errors to bubble up to the global interceptor