### PR TITLE
feat: export members of organization

### DIFF
--- a/src/modules/organisations/organisations.controller.ts
+++ b/src/modules/organisations/organisations.controller.ts
@@ -204,31 +204,31 @@ export class OrganisationsController {
   // async getById(@Param('org_id') org_id: string) {
   //   return this.organisationsService.getOrganizationDetailsById(org_id);
   // }
-  // @ApiOperation({ summary: 'Export members of an Organisation to a CSV file' })
-  // @ApiResponse({
-  //   status: 200,
-  // })
-  // @ApiResponse({
-  //   status: 200,
-  //   description: 'The CSV file containing organisation members is returned.',
-  //   headers: {
-  //     'Content-Type': {
-  //       description: 'The content type of the response, which is text/csv.',
-  //       schema: {
-  //         type: 'string',
-  //         example: 'text/csv',
-  //       },
-  //     },
-  //     'Content-Disposition': {
-  //       description: 'Indicates that the content is an attachment with a filename.',
-  //       schema: {
-  //         type: 'string',
-  //         example: 'attachment; filename="organisation-members-{orgId}.csv"',
-  //       },
-  //     },
-  //   },
-  // })
 
+  @ApiOperation({ summary: 'Export members of an Organisation to a CSV file' })
+  @ApiResponse({
+    status: 200,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The CSV file containing organisation members is returned.',
+    headers: {
+      'Content-Type': {
+        description: 'The content type of the response, which is text/csv.',
+        schema: {
+          type: 'string',
+          example: 'text/csv',
+        },
+      },
+      'Content-Disposition': {
+        description: 'Indicates that the content is an attachment with a filename.',
+        schema: {
+          type: 'string',
+          example: 'attachment; filename="organisation-members-{orgId}.csv"',
+        },
+      },
+    },
+  })
   @UseGuards(OwnershipGuard)
   @Get(':org_id/members/export')
   async exportOrganisationMembers(

--- a/src/modules/organisations/organisations.controller.ts
+++ b/src/modules/organisations/organisations.controller.ts
@@ -229,33 +229,33 @@ export class OrganisationsController {
   //   },
   // })
 
-  // @UseGuards(OwnershipGuard)
-  // @Get(':org_id/members/export')
-  // async exportOrganisationMembers(
-  //   @Param('org_id', ParseUUIDPipe) orgId: string,
-  //   @Req() req: Request,
-  //   @Res() res: Response
-  // ) {
-  //   const userId = req['user'].id;
-  //   const filePath = await this.organisationsService.exportOrganisationMembers(orgId, userId);
+  @UseGuards(OwnershipGuard)
+  @Get(':org_id/members/export')
+  async exportOrganisationMembers(
+    @Param('org_id', ParseUUIDPipe) orgId: string,
+    @Req() req: Request,
+    @Res() res: Response
+  ) {
+    const userId = req['user'].id;
+    const filePath = await this.organisationsService.exportOrganisationMembers(orgId, userId);
 
-  //   res.set({
-  //     'Content-Type': 'text/csv',
-  //     'Content-Disposition': `attachment; filename="organisation-members-${orgId}.csv"`,
-  //   });
+    res.set({
+      'Content-Type': 'text/csv',
+      'Content-Disposition': `attachment; filename="organisation-members-${orgId}.csv"`,
+    });
 
-  //   const fileStream = createReadStream(filePath);
+    const fileStream = createReadStream(filePath);
 
-  //   pipeline(fileStream, res)
-  //     .then(() => unlink(filePath))
-  //     .catch(error => {
-  //       this.logger.error('Pipeline failed:', error.stack);
-  //       if (!res.headersSent) {
-  //         res.status(500).send('Internal Server Error');
-  //       }
-  //       return unlink(filePath).catch(unlinkError => {
-  //         this.logger.error(`Failed to delete file: ${unlinkError.message}`, unlinkError.stack);
-  //       });
-  //     });
-  // }
+    pipeline(fileStream, res)
+      .then(() => unlink(filePath))
+      .catch(error => {
+        this.logger.error('Pipeline failed:', error.stack);
+        if (!res.headersSent) {
+          res.status(500).send('Internal Server Error');
+        }
+        return unlink(filePath).catch(unlinkError => {
+          this.logger.error(`Failed to delete file: ${unlinkError.message}`, unlinkError.stack);
+        });
+      });
+  }
 }

--- a/src/modules/organisations/organisations.service.ts
+++ b/src/modules/organisations/organisations.service.ts
@@ -21,6 +21,9 @@ import CreateOrganisationType from './dto/create-organisation-options';
 import { CustomHttpException } from '../../helpers/custom-http-filter';
 import { ORG_NOT_FOUND, ORG_UPDATE } from '../../helpers/SystemMessages';
 import { OrganisationMemberMapper } from './mapper/org-members.mapper';
+import { createObjectCsvStringifier } from 'csv-writer';
+import { join } from 'path';
+import * as fs from 'fs';
 
 @Injectable()
 export class OrganisationsService {
@@ -53,7 +56,7 @@ export class OrganisationsService {
     if (!members.length) {
       return { status_code: HttpStatus.OK, message: 'members retrieved successfully', data: [] };
     }
-    let organisationMembers = members.map(instance => instance.user);
+    const organisationMembers = members.map(instance => instance.user);
 
     const isMember = organisationMembers.find(member => member.id === sub);
     if (!isMember) throw new ForbiddenException('User does not have access to the organisation');
@@ -293,23 +296,23 @@ export class OrganisationsService {
   //   return { message: 'Fetched Organization Details Successfully', data: orgDetails };
   // }
 
-  // async exportOrganisationMembers(orgId: string, userId: string): Promise<string> {
-  //   const membersResponse = await this.getOrganisationMembers(orgId, 1, Number.MAX_SAFE_INTEGER, userId);
+  async exportOrganisationMembers(orgId: string, userId: string): Promise<string> {
+    const membersResponse = await this.getOrganisationMembers(orgId, 1, Number.MAX_SAFE_INTEGER, userId);
 
-  //   const csvStringifier = createObjectCsvStringifier({
-  //     header: [
-  //       { id: 'id', title: 'ID' },
-  //       { id: 'name', title: 'Name' },
-  //       { id: 'email', title: 'Email' },
-  //       { id: 'role', title: 'Role' },
-  //     ],
-  //   });
+    const csvStringifier = createObjectCsvStringifier({
+      header: [
+        { id: 'id', title: 'ID' },
+        { id: 'name', title: 'Name' },
+        { id: 'email', title: 'Email' },
+        { id: 'role', title: 'Role' },
+      ],
+    });
 
-  //   const csvData = csvStringifier.getHeaderString() + csvStringifier.stringifyRecords(membersResponse.data);
+    const csvData = csvStringifier.getHeaderString() + csvStringifier.stringifyRecords(membersResponse.data);
 
-  //   const filePath = join(__dirname, `organisation-members-${orgId}.csv`);
-  //   fs.writeFileSync(filePath, csvData);
+    const filePath = join(__dirname, `organisation-members-${orgId}.csv`);
+    fs.writeFileSync(filePath, csvData);
 
-  //   return filePath;
-  // }
+    return filePath;
+  }
 }

--- a/src/modules/organisations/organisations.service.ts
+++ b/src/modules/organisations/organisations.service.ts
@@ -304,7 +304,6 @@ export class OrganisationsService {
         { id: 'id', title: 'ID' },
         { id: 'name', title: 'Name' },
         { id: 'email', title: 'Email' },
-        { id: 'role', title: 'Role' },
       ],
     });
 


### PR DESCRIPTION
**What does this PR do?**

This PR introduces an endpoint that enables the export of organisation members to a CSV file. The endpoint will generate a CSV file containing details of all members in an organisation, including their ID, name, email, and role.

**How to Test**

**Export Organisation Members to CSV:**

- Use the endpoint `GET /api/v1/organisations/:org_id/members/export` to export members of an organisation by their organisation ID.

**Verify CSV Export:**

- Check if the CSV file is created with the expected headers (ID, Name, Email, Role) and member data.
- Ensure that the file is downloadable and the data matches the organisation members' details in the database.

**Edge Cases**

- Test whether the organisation exists before attempting to export members.
- Test the behaviour of the system when trying to export members from an organisation that does not exist.
- Test the export functionality for an organisation with no members.

**Checklist**

- Implementing the `/api/v1/organisations/:org_id/members/export` endpoint for exporting members to a CSV file.
- Validating the `org_id` parameter to ensure it refers to an existing organisation.
- Using the `csv-writer` module to generate the CSV file.
- Writing tests to validate the CSV export functionality and edge cases.
