### PR TITLE
fix: internal server error

### DIFF
--- a/src/modules/user/tests/user.service.spec.ts
+++ b/src/modules/user/tests/user.service.spec.ts
@@ -28,6 +28,12 @@ describe('UserService', () => {
     findAndCount: jest.fn(),
     count: jest.fn(),
     softDelete: jest.fn(),
+    metadata: {
+      relations: [
+        { relationType: 'one-to-many', propertyName: 'owned_organisations' },
+        { relationType: 'one-to-many', propertyName: 'jobs' },
+      ],
+    },
   };
 
   const mockResponse: Partial<Response> = {

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -355,7 +355,6 @@ export default class UserService {
     const omitColumns: Array<keyof User> = ['password'];
     const relations = [
       'profile',
-      'organisationMembers',
       'created_organisations',
       'owned_organisations',
       'blogs',
@@ -364,7 +363,9 @@ export default class UserService {
     ];
     const user = await this.userRepository.findOne({
       where: { id: userId },
-      relations,
+      relations: this.userRepository.metadata.relations
+        .filter(relation => relation.relationType === 'one-to-many')
+        .map(relation => relation.propertyName),
     });
 
     for (const i in user) {


### PR DESCRIPTION
## What does this PR do?
This PR issues a fix on `/api/v1/users/export` that throws an `internal server error` when the user request for his data.

## How should this be manually tested?
Send a POST request to this endpoint:

**GET** `/api/v1/users/export`

**Request Headers**:
```json
{
   "Authorization": "Bearer <token>"
}
```

- Error Response (400):
```json
{
  "message": "Admin Role does not exist",
  "status_code": 400
}
```
- Error Response (401):
```json
{
  "message": "User is currently unauthorized, kindly authenticate to continue",
  "status_code": 401
}
```

## Checklist of what you did
 - [x] Improve the code in the User Service to exclude relations with no join column
 - [x] Write unit tests to make sure that everything works.


## Test Screenshot
![Screenshot from 2024-08-10 09-05-17](https://github.com/user-attachments/assets/f4693e5c-b90d-4ba8-8379-7ef64e77ce3b)

## Reference Issue
https://github.com/hngprojects/hng_boilerplate_nestjs/issues/138