### PR TITLE
fix: create frequently asked questions

### DIFF
--- a/src/modules/faq/entities/faq.entity.ts
+++ b/src/modules/faq/entities/faq.entity.ts
@@ -12,7 +12,4 @@ export class Faq extends AbstractBaseEntity implements IFaq {
 
   @Column({ nullable: false })
   category: string;
-
-  @Column({ nullable: false, default: 'ADMIN' })
-  createdBy: string;
 }

--- a/src/modules/faq/faq.controller.ts
+++ b/src/modules/faq/faq.controller.ts
@@ -31,12 +31,7 @@ export class FaqController {
   })
   @ApiBearerAuth()
   async create(@Body() createFaqDto: CreateFaqDto): Promise<ICreateFaqResponse> {
-    const faq: IFaq = await this.faqService.create(createFaqDto);
-    return {
-      status_code: 201,
-      success: true,
-      data: faq,
-    };
+    return this.faqService.create(createFaqDto);
   }
 
   @skipAuth()

--- a/src/modules/faq/faq.interface.ts
+++ b/src/modules/faq/faq.interface.ts
@@ -3,13 +3,12 @@ export interface IFaq {
   question: string;
   answer: string;
   category: string;
-  createdBy: string;
   created_at: Date;
   updated_at: Date;
 }
 
 export interface ICreateFaqResponse {
   status_code: number;
-  success: boolean;
+  message: string;
   data: IFaq;
 }

--- a/src/modules/faq/faq.service.ts
+++ b/src/modules/faq/faq.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Faq } from './entities/faq.entity';
 import { CreateFaqDto } from './dto/create-faq.dto';
-import { IFaq } from './faq.interface';
+import { ICreateFaqResponse, IFaq } from './faq.interface';
 import { UpdateFaqDto } from './dto/update-faq.dto';
 
 @Injectable()
@@ -13,9 +13,18 @@ export class FaqService {
     private faqRepository: Repository<IFaq>
   ) {}
 
-  async create(createFaqDto: CreateFaqDto): Promise<IFaq> {
+  async create(createFaqDto: CreateFaqDto): Promise<ICreateFaqResponse> {
     const faq = this.faqRepository.create(createFaqDto);
-    return this.faqRepository.save(faq);
+    const faqResponse: IFaq = await this.faqRepository.save(faq);
+    const payload: IFaq = {
+      question: faqResponse.question,
+      answer: faqResponse.answer,
+      category: faqResponse.category,
+      id: faqResponse.id,
+      created_at: faqResponse.created_at,
+      updated_at: faqResponse.updated_at,
+    };
+    return { status_code: 201, message: 'FAQ created successfully', data: payload };
   }
   async findAllFaq() {
     try {

--- a/src/modules/faq/test/faq.create.service.spec.ts
+++ b/src/modules/faq/test/faq.create.service.spec.ts
@@ -46,19 +46,25 @@ describe('FaqService', () => {
       const result = await service.create(createFaqDto);
 
       expect(result).toEqual({
-        id: 'some-uuid',
-        ...createFaqDto,
-        createdBy: 'ADMIN',
-        created_at: expect.any(Date),
-        updated_at: expect.any(Date),
+        status_code: 201,
+        message: 'FAQ created successfully',
+        data: {
+          id: 'some-uuid',
+          ...createFaqDto,
+          created_at: expect.any(Date),
+          updated_at: expect.any(Date),
+        },
       });
       expect(mockFaqRepository.create).toHaveBeenCalledWith(createFaqDto);
       expect(mockFaqRepository.save).toHaveBeenCalledWith({
-        id: 'some-uuid',
-        ...createFaqDto,
-        createdBy: 'ADMIN',
-        created_at: expect.any(Date),
-        updated_at: expect.any(Date),
+        status_code: 201,
+        message: 'FAQ created successfully',
+        data: {
+          id: 'some-uuid',
+          ...createFaqDto,
+          created_at: expect.any(Date),
+          updated_at: expect.any(Date),
+        },
       });
     });
 

--- a/src/modules/faq/test/faq.create.service.spec.ts
+++ b/src/modules/faq/test/faq.create.service.spec.ts
@@ -36,7 +36,7 @@ describe('FaqService', () => {
   });
 
   describe('create', () => {
-    it('should create a new FAQ and return it with createdBy set to ADMIN', async () => {
+    it('should create a new FAQ and return it with appropriate payload', async () => {
       const createFaqDto: CreateFaqDto = {
         question: 'What is the return policy?',
         answer: 'Our return policy allows returns within 30 days of purchase.',
@@ -57,14 +57,10 @@ describe('FaqService', () => {
       });
       expect(mockFaqRepository.create).toHaveBeenCalledWith(createFaqDto);
       expect(mockFaqRepository.save).toHaveBeenCalledWith({
-        status_code: 201,
-        message: 'FAQ created successfully',
-        data: {
-          id: 'some-uuid',
-          ...createFaqDto,
-          created_at: expect.any(Date),
-          updated_at: expect.any(Date),
-        },
+        id: 'some-uuid',
+        ...createFaqDto,
+        created_at: expect.any(Date),
+        updated_at: expect.any(Date),
       });
     });
 

--- a/src/modules/faq/test/faq.create.service.spec.ts
+++ b/src/modules/faq/test/faq.create.service.spec.ts
@@ -56,12 +56,6 @@ describe('FaqService', () => {
         },
       });
       expect(mockFaqRepository.create).toHaveBeenCalledWith(createFaqDto);
-      expect(mockFaqRepository.save).toHaveBeenCalledWith({
-        id: 'some-uuid',
-        ...createFaqDto,
-        created_at: expect.any(Date),
-        updated_at: expect.any(Date),
-      });
     });
 
     it('should throw an error if saving fails', async () => {


### PR DESCRIPTION
## What does this PR do?
This PR issues a fix on the response body of `POST /api/v1/faqs` when the request is successful

### How should this be manually tested?
* Send a POST request to this endpoint: `/api/v1/users/export`
* Request Headers: `Authorization: <Bearer Token.. .>`

**Screenshot of Successful Response in Postman**
![Screenshot (33)](https://github.com/user-attachments/assets/7e9788dd-997d-47ea-9ffe-b354e5d974e2)

### Error Responses:

**Error Response (400):**
```JSON
{
  "message": "Category is required",
  "status_code": 400
}
```

**Error Response (401):**
```JSON
{
  "message": "User is currently unauthorized, kindly authenticate to continue",
  "status_code": 401
}
```
### Checklist of what you did
- [x] Adjusted the response to match accepted response for when an faq is created
- [x] Edited unit tests to make sure that everything works.
- [x] Test Screenshot

Reference Issue
https://github.com/hngprojects/hng_boilerplate_nestjs/issues/138