### PR TITLE
fix: billing docs and added update and delete endpoints

### DIFF
--- a/src/helpers/SystemMessages.ts
+++ b/src/helpers/SystemMessages.ts
@@ -109,3 +109,4 @@ export const BILLING_PLAN_CREATED = 'Billing plan successfully created';
 export const TOPIC_NOT_FOUND = `Help center topic with ID not found`;
 export const TOPIC_UPDATE_SUCCESS = 'Topic updated successfully';
 export const TOPIC_DELETED = 'Topic deleted successfully';
+export const BILLING_PLAN_NOT_FOUND = 'Billing plan not found';

--- a/src/modules/billing-plans/billing-plan.controller.ts
+++ b/src/modules/billing-plans/billing-plan.controller.ts
@@ -4,6 +4,7 @@ import { SuperAdminGuard } from '../../guards/super-admin.guard';
 import { BillingPlanService } from './billing-plan.service';
 import { skipAuth } from '../../helpers/skipAuth';
 import { BillingPlanDto } from './dto/billing-plan.dto';
+import { createBillingPlanDocs, getAllBillingPlansDocs, getSingleBillingPlan } from './docs/billing-plan-docs';
 
 @ApiTags('Billing Plans')
 @Controller('billing-plans')
@@ -11,31 +12,22 @@ export class BillingPlanController {
   constructor(private readonly billingPlanService: BillingPlanService) {}
 
   @Post('/')
+  @createBillingPlanDocs()
   @UseGuards(SuperAdminGuard)
-  @ApiBearerAuth()
-  @ApiOperation({ summary: 'Create billing plans' })
-  @ApiBody({ type: BillingPlanDto })
-  @ApiResponse({ status: 201, description: 'Billing plan created successfully.', type: BillingPlanDto })
-  @ApiResponse({ status: 200, description: 'Billing plan already exists in the database.', type: [BillingPlanDto] })
   async createBillingPlan(@Body() createBillingPlanDto: BillingPlanDto) {
     return this.billingPlanService.createBillingPlan(createBillingPlanDto);
   }
 
   @skipAuth()
+  @getAllBillingPlansDocs()
   @Get('/')
-  @ApiOperation({ summary: 'Get all billing plans' })
-  @ApiResponse({ status: 200, description: 'Billing plans retrieved successfully.', type: [BillingPlanDto] })
-  @ApiResponse({ status: 404, description: 'No billing plans found.' })
   async getAllBillingPlans() {
     return this.billingPlanService.getAllBillingPlans();
   }
 
   @skipAuth()
+  @getSingleBillingPlan()
   @Get('/:id')
-  @ApiOperation({ summary: 'Get single billing plan by ID' })
-  @ApiResponse({ status: 200, description: 'Billing plan retrieved successfully', type: BillingPlanDto })
-  @ApiResponse({ status: 400, description: 'Invalid billing plan ID' })
-  @ApiResponse({ status: 404, description: 'Billing plan not found' })
   async getSingleBillingPlan(@Param('id') id: string) {
     return this.billingPlanService.getSingleBillingPlan(id);
   }

--- a/src/modules/billing-plans/billing-plan.controller.ts
+++ b/src/modules/billing-plans/billing-plan.controller.ts
@@ -18,10 +18,10 @@ import { skipAuth } from '../../helpers/skipAuth';
 import { BillingPlanDto } from './dto/billing-plan.dto';
 import {
   createBillingPlanDocs,
-  deleteBillingPlan,
+  deleteBillingPlanDocs,
   getAllBillingPlansDocs,
-  getSingleBillingPlan,
-  updateBillingPlan,
+  getSingleBillingPlanDocs,
+  updateBillingPlanDocs,
 } from './docs/billing-plan-docs';
 import { UpdateBillingPlanDto } from './dto/update-billing-plan.dto';
 
@@ -45,14 +45,14 @@ export class BillingPlanController {
   }
 
   @skipAuth()
-  @getSingleBillingPlan()
+  @getSingleBillingPlanDocs()
   @Get('/:id')
   async getSingleBillingPlan(@Param('id') id: string) {
     return this.billingPlanService.getSingleBillingPlan(id);
   }
 
   @UseGuards(SuperAdminGuard)
-  @updateBillingPlan()
+  @updateBillingPlanDocs()
   @Patch('/:id')
   async updateBillingPlan(
     @Param('id', new ParseUUIDPipe()) id: string,
@@ -62,7 +62,7 @@ export class BillingPlanController {
   }
 
   @UseGuards(SuperAdminGuard)
-  @deleteBillingPlan()
+  @deleteBillingPlanDocs()
   @Delete('/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
   async deleteBillingPlan(@Param('id', ParseUUIDPipe) id: string) {

--- a/src/modules/billing-plans/billing-plan.controller.ts
+++ b/src/modules/billing-plans/billing-plan.controller.ts
@@ -1,10 +1,29 @@
-import { Controller, Get, Param, Post, Body, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags, ApiBody } from '@nestjs/swagger';
+import {
+  Controller,
+  Get,
+  Param,
+  Post,
+  Body,
+  UseGuards,
+  Patch,
+  ParseUUIDPipe,
+  Delete,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { SuperAdminGuard } from '../../guards/super-admin.guard';
 import { BillingPlanService } from './billing-plan.service';
 import { skipAuth } from '../../helpers/skipAuth';
 import { BillingPlanDto } from './dto/billing-plan.dto';
-import { createBillingPlanDocs, getAllBillingPlansDocs, getSingleBillingPlan } from './docs/billing-plan-docs';
+import {
+  createBillingPlanDocs,
+  deleteBillingPlan,
+  getAllBillingPlansDocs,
+  getSingleBillingPlan,
+  updateBillingPlan,
+} from './docs/billing-plan-docs';
+import { UpdateBillingPlanDto } from './dto/update-billing-plan.dto';
 
 @ApiTags('Billing Plans')
 @Controller('billing-plans')
@@ -30,5 +49,23 @@ export class BillingPlanController {
   @Get('/:id')
   async getSingleBillingPlan(@Param('id') id: string) {
     return this.billingPlanService.getSingleBillingPlan(id);
+  }
+
+  @UseGuards(SuperAdminGuard)
+  @updateBillingPlan()
+  @Patch('/:id')
+  async updateBillingPlan(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() updateBillingPlanDto: UpdateBillingPlanDto
+  ) {
+    return this.billingPlanService.updateBillingPlan(id, updateBillingPlanDto);
+  }
+
+  @UseGuards(SuperAdminGuard)
+  @deleteBillingPlan()
+  @Delete('/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteBillingPlan(@Param('id', ParseUUIDPipe) id: string) {
+    return this.billingPlanService.deleteBillingPlan(id);
   }
 }

--- a/src/modules/billing-plans/billing-plan.service.ts
+++ b/src/modules/billing-plans/billing-plan.service.ts
@@ -67,7 +67,6 @@ export class BillingPlanService {
 
   async updateBillingPlan(id: string, updateBillingPlanDto: UpdateBillingPlanDto): Promise<BillingPlan> {
     const billing_plan = await this.billingPlanRepository.findOneBy({ id });
-    console.log(billing_plan);
     if (!billing_plan) {
       throw new CustomHttpException(SYS_MSG.BILLING_PLAN_NOT_FOUND, HttpStatus.NOT_FOUND);
     }

--- a/src/modules/billing-plans/billing-plan.service.ts
+++ b/src/modules/billing-plans/billing-plan.service.ts
@@ -6,6 +6,7 @@ import { BillingPlanDto } from './dto/billing-plan.dto';
 import * as SYS_MSG from '../../helpers/SystemMessages';
 import { CustomHttpException } from '../../helpers/custom-http-filter';
 import { BillingPlanMapper } from './mapper/billing-plan.mapper';
+import { UpdateBillingPlanDto } from './dto/update-billing-plan.dto';
 
 @Injectable()
 export class BillingPlanService {
@@ -62,5 +63,23 @@ export class BillingPlanService {
       message: 'Billing plan retrieved successfully',
       data: plan,
     };
+  }
+
+  async updateBillingPlan(id: string, updateBillingPlanDto: UpdateBillingPlanDto): Promise<BillingPlan> {
+    const billing_plan = await this.billingPlanRepository.findOneBy({ id });
+    console.log(billing_plan);
+    if (!billing_plan) {
+      throw new CustomHttpException(SYS_MSG.BILLING_PLAN_NOT_FOUND, HttpStatus.NOT_FOUND);
+    }
+    Object.assign(billing_plan, updateBillingPlanDto);
+    return await this.billingPlanRepository.save(billing_plan);
+  }
+
+  async deleteBillingPlan(id: string): Promise<void> {
+    const billing_plan = await this.billingPlanRepository.findOne({ where: { id: id } });
+    if (!billing_plan) {
+      throw new CustomHttpException(SYS_MSG.BILLING_PLAN_NOT_FOUND, HttpStatus.NOT_FOUND);
+    }
+    await this.billingPlanRepository.delete(id);
   }
 }

--- a/src/modules/billing-plans/docs/billing-plan-docs.ts
+++ b/src/modules/billing-plans/docs/billing-plan-docs.ts
@@ -21,7 +21,7 @@ export function getAllBillingPlansDocs() {
   );
 }
 
-export function getSingleBillingPlan() {
+export function getSingleBillingPlanDocs() {
   return applyDecorators(
     ApiOperation({ summary: 'Get single billing plan by ID' }),
     ApiResponse({ status: 200, description: 'Billing plan retrieved successfully', type: BillingPlanDto }),
@@ -30,7 +30,7 @@ export function getSingleBillingPlan() {
   );
 }
 
-export function updateBillingPlan() {
+export function updateBillingPlanDocs() {
   return applyDecorators(
     ApiOperation({ summary: 'Update a billing plan by ID' }),
     ApiResponse({ status: 200, description: 'Billing plan updated successfully.', type: BillingPlan }),
@@ -38,7 +38,7 @@ export function updateBillingPlan() {
   );
 }
 
-export function deleteBillingPlan() {
+export function deleteBillingPlanDocs() {
   return applyDecorators(
     ApiOperation({ summary: 'Delete a billing plan by ID' }),
     ApiResponse({ status: 204, description: 'Billing plan deleted successfully.' }),

--- a/src/modules/billing-plans/docs/billing-plan-docs.ts
+++ b/src/modules/billing-plans/docs/billing-plan-docs.ts
@@ -1,6 +1,7 @@
 import { applyDecorators } from '@nestjs/common';
 import { BillingPlanDto } from '../dto/billing-plan.dto';
 import { ApiBearerAuth, ApiBody, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { BillingPlan } from '../entities/billing-plan.entity';
 
 export function createBillingPlanDocs() {
   return applyDecorators(
@@ -26,5 +27,21 @@ export function getSingleBillingPlan() {
     ApiResponse({ status: 200, description: 'Billing plan retrieved successfully', type: BillingPlanDto }),
     ApiResponse({ status: 400, description: 'Invalid billing plan ID' }),
     ApiResponse({ status: 404, description: 'Billing plan not found' })
+  );
+}
+
+export function updateBillingPlan() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Update a billing plan by ID' }),
+    ApiResponse({ status: 200, description: 'Billing plan updated successfully.', type: BillingPlan }),
+    ApiResponse({ status: 404, description: 'Billing plan not found.' })
+  );
+}
+
+export function deleteBillingPlan() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Delete a billing plan by ID' }),
+    ApiResponse({ status: 204, description: 'Billing plan deleted successfully.' }),
+    ApiResponse({ status: 404, description: 'Billing plan not found.' })
   );
 }

--- a/src/modules/billing-plans/docs/billing-plan-docs.ts
+++ b/src/modules/billing-plans/docs/billing-plan-docs.ts
@@ -1,0 +1,30 @@
+import { applyDecorators } from '@nestjs/common';
+import { BillingPlanDto } from '../dto/billing-plan.dto';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export function createBillingPlanDocs() {
+  return applyDecorators(
+    ApiBearerAuth(),
+    ApiOperation({ summary: 'Create billing plans' }),
+    ApiBody({ type: BillingPlanDto }),
+    ApiResponse({ status: 201, description: 'Billing plan created successfully.', type: BillingPlanDto }),
+    ApiResponse({ status: 200, description: 'Billing plan already exists in the database.', type: [BillingPlanDto] })
+  );
+}
+
+export function getAllBillingPlansDocs() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Get all billing plans' }),
+    ApiResponse({ status: 200, description: 'Billing plans retrieved successfully.', type: [BillingPlanDto] }),
+    ApiResponse({ status: 404, description: 'No billing plans found.' })
+  );
+}
+
+export function getSingleBillingPlan() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Get single billing plan by ID' }),
+    ApiResponse({ status: 200, description: 'Billing plan retrieved successfully', type: BillingPlanDto }),
+    ApiResponse({ status: 400, description: 'Invalid billing plan ID' }),
+    ApiResponse({ status: 404, description: 'Billing plan not found' })
+  );
+}

--- a/src/modules/billing-plans/dto/update-billing-plan.dto.ts
+++ b/src/modules/billing-plans/dto/update-billing-plan.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { BillingPlanDto } from './billing-plan.dto';
+
+export class UpdateBillingPlanDto extends PartialType(BillingPlanDto) {}


### PR DESCRIPTION
### What does the PR do?

#Closes: #1100 
This PR introduces new functionality for updating and deleting billing plans. It adds endpoints for modifying existing billing plans and removing them from the database. The `updateBillingPlan` method allows for partial updates to a billing plan, and the `deleteBillingPlan` method handles the deletion of a billing plan by ID. Additionally, Swagger API documentation has been enhanced with custom decorators for better reusability and cleaner code.

**How should this be manually tested?**

1. **Test the `updateBillingPlan` Endpoint:**
   - Send a `PATCH` request to `/billing-plans/:id` with a valid billing plan ID and an updated payload.
   - Verify that the billing plan is updated correctly in the database.
   - Test with an invalid billing plan ID to ensure that it returns a `404 Not Found` error.

2. **Test the `deleteBillingPlan` Endpoint:**
   - Send a `DELETE` request to `/billing-plans/:id` with a valid billing plan ID.
   - Confirm that the billing plan is removed from the database.
   - Test with an invalid billing plan ID to ensure that it returns a `404 Not Found` error.

3. **Verify Swagger Documentation:**
   - Access the Swagger documentation for the API.
   - Ensure that the `update` and `delete` endpoints are documented with the correct details and response types.

**Checklist of what you did:**
- Implemented `updateBillingPlan` method in the controller to allow partial updates of billing plans.
- Implemented `deleteBillingPlan` method in the controller to enable deletion of billing plans.
- Updated the `BillingPlanService` to include logic for updating and deleting billing plans.
- Created custom Swagger decorators for `PATCH` and `DELETE` endpoints to manage API documentation.
- Ensured error handling is in place for invalid billing plan IDs.
