### PR TITLE
fix: correcting link in forgot password

### DIFF
--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -97,7 +97,7 @@ export default class AuthenticationService {
     }
 
     const token = (await this.otpService.createOtp(user.id)).token;
-    await this.emailService.sendForgotPasswordMail(user.email, `${process.env.BASE_URL}/auth/reset-password`, token);
+    await this.emailService.sendForgotPasswordMail(user.email, `${process.env.FRONTEND_URL}/forgot-password`, token);
 
     return {
       message: SYS_MSG.EMAIL_SENT,

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -97,7 +97,7 @@ export default class AuthenticationService {
     }
 
     const token = (await this.otpService.createOtp(user.id)).token;
-    await this.emailService.sendForgotPasswordMail(user.email, `${process.env.FRONTEND_URL}/forgot-password`, token);
+    await this.emailService.sendForgotPasswordMail(user.email, `${process.env.FRONTEND_URL}/reset-password`, token);
 
     return {
       message: SYS_MSG.EMAIL_SENT,


### PR DESCRIPTION
## What does this PR do?
This PR ensures that the forgot password email send a link to the frontend user interface instead of the backend endpoint

## How Can This Be Manually Tested?
1. Request to change your password by sending a request to `api/v1/auth/forgot-password`
2. Check your email and click the link
3. You should be re-directed to the FE page

## Tasks
- [x] Changed the url in the forgot password email

## Reference Issue
#1085 