### PR TITLE
[FIX]:Fixed nestjs server start up

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,9 @@
-import eslint from '@eslint/js';
-import tseslint from '@typescript-eslint/eslint-plugin';
-import tsParser from '@typescript-eslint/parser';
-import importPlugin from 'eslint-plugin-import';
+const eslint = require('@eslint/js');
+const tseslint = require('@typescript-eslint/eslint-plugin');
+const tsParser = require('@typescript-eslint/parser');
+const importPlugin = require('eslint-plugin-import');
 
-export default [
+module.exports = [
   eslint.configs.recommended,
   {
     files: ['**/*.{ts,tsx}'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "hng_boilerplate_nestjs",
-  "type": "module",
   "version": "0.0.1",
   "description": "",
   "author": "",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,7 +5,7 @@ import { Module, ValidationPipe } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { APP_PIPE } from '@nestjs/core';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { object, string, number } from 'joi';
+import * as Joi from 'joi';
 import { LoggerModule } from 'nestjs-pino';
 import authConfig from '@config/auth.config';
 import serverConfig from '@config/server.config';
@@ -83,10 +83,10 @@ import { ApiStatusModule } from '@modules/api-status/api-status.module';
       envFilePath: ['.env.development.local', `.env.${process.env.PROFILE}`],
       isGlobal: true,
       load: [serverConfig, authConfig],
-      validationSchema: object({
-        NODE_ENV: string().valid('development', 'production', 'test', 'provision').required(),
-        PROFILE: string().valid('local', 'development', 'production', 'ci', 'testing', 'staging').required(),
-        PORT: number().required(),
+      validationSchema: Joi.object({
+        NODE_ENV: Joi.string().valid('development', 'production', 'test', 'provision').required(),
+        PROFILE: Joi.string().valid('local', 'development', 'production', 'ci', 'testing', 'staging').required(),
+        PORT: Joi.number().required(),
       }),
     }),
     LoggerModule.forRoot(),

--- a/src/modules/organisations/organisations.module.ts
+++ b/src/modules/organisations/organisations.module.ts
@@ -10,6 +10,7 @@ import { Role } from '@modules/role/entities/role.entity';
 import { Profile } from '@modules/profile/entities/profile.entity';
 import { UserModule } from '@modules/user/user.module';
 import { InviteModule } from '@modules/invite/invite.module';
+import { Permissions } from '@modules/permissions/entities/permissions.entity';
 
 @Module({
   imports: [

--- a/src/modules/role/role.module.ts
+++ b/src/modules/role/role.module.ts
@@ -7,6 +7,7 @@ import { Role } from './entities/role.entity';
 import { User } from '@modules/user/entities/user.entity';
 import { DefaultPermissions } from '@modules/permissions/entities/default-permissions.entity';
 import { Organisation } from '@modules/organisations/entities/organisations.entity';
+import { Permissions } from '@modules/permissions/entities/permissions.entity';
 
 @Module({
   imports: [


### PR DESCRIPTION

**fix:** removed type property from package.json and instantiated Joi in AppModule

**Description:**  
- Removed the `"type"` property from `package.json` to avoid ESM/CJS module resolution conflicts.  
- Switched to a full `* as Joi` import in `AppModule` and used `Joi.object(...)` for the `validationSchema`, ensuring the ConfigModule receives a valid Joi instance and preventing the “Must be a Joi instance” error.