### PR TITLE
feat: unsubscribe newsletter

### DIFF
--- a/src/modules/newsletter-subscription/dto/unsubscribe-newsletter.dto.ts
+++ b/src/modules/newsletter-subscription/dto/unsubscribe-newsletter.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail } from 'class-validator';
+
+export class UnsubscribeNewsletterDto {
+  @ApiProperty({ description: 'Email of the user to unsubscribe' })
+  @IsEmail()
+  email: string;
+}

--- a/src/modules/newsletter-subscription/entities/newsletter-subscription.entity.ts
+++ b/src/modules/newsletter-subscription/entities/newsletter-subscription.entity.ts
@@ -8,4 +8,7 @@ export class NewsletterSubscription extends AbstractBaseEntity {
 
   @DeleteDateColumn()
   deletedAt: Date;
+
+  @Column({ default: false })
+  isUnsubscribed: boolean;
 }

--- a/src/modules/newsletter-subscription/newsletter-subscription.controller.ts
+++ b/src/modules/newsletter-subscription/newsletter-subscription.controller.ts
@@ -5,6 +5,7 @@ import { skipAuth } from '@shared/helpers/skipAuth';
 import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { NewsletterSubscriptionResponseDto } from './dto/newsletter-subscription.response.dto';
 import { SuperAdminGuard } from '@guards/super-admin.guard';
+import { UnsubscribeNewsletterDto } from './dto/unsubscribe-newsletter.dto';
 
 @ApiTags('Newsletter Subscription')
 @Controller('newsletter-subscription')
@@ -114,5 +115,15 @@ export class NewsletterSubscriptionController {
   @ApiResponse({ status: 404, description: 'Subscriber with ID ${id} not found or already restored' })
   restore(@Param('id') id: string) {
     return this.newsletterSubscriptionService.restore(id);
+  }
+
+  @Post('unsubscribe')
+  @skipAuth()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Unsubscribe from the newsletter' })
+  @ApiResponse({ status: 200, description: 'User has been unsubscribed successfully.' })
+  @ApiResponse({ status: 404, description: 'Email not found' })
+  unsubscribe(@Body() unsubscribeDto: UnsubscribeNewsletterDto) {
+    return this.newsletterSubscriptionService.unsubscribe(unsubscribeDto.email);
   }
 }

--- a/src/modules/newsletter-subscription/newsletter-subscription.service.ts
+++ b/src/modules/newsletter-subscription/newsletter-subscription.service.ts
@@ -72,4 +72,17 @@ export class NewsletterSubscriptionService {
       email: newsletterSubscription.email,
     };
   }
+
+  async unsubscribe(email: string) {
+    const subscription = await this.newsletterSubscriptionRepository.findOne({ where: { email } });
+
+    if (!subscription) {
+      throw new NotFoundException(`Email ${email} not found in the subscription list`);
+    }
+
+    subscription.isUnsubscribed = true;
+    await this.newsletterSubscriptionRepository.save(subscription);
+
+    return { message: `Email ${email} has been unsubscribed successfully` };
+  }
 }

--- a/src/modules/newsletter-subscription/tests/newsletter-subscription.service.spec.ts
+++ b/src/modules/newsletter-subscription/tests/newsletter-subscription.service.spec.ts
@@ -146,4 +146,47 @@ describe('NewsletterService', () => {
       await expect(service.restore(id)).rejects.toThrow(NotFoundException);
     });
   });
+
+  describe('unsubscribe', () => {
+    it('should successfully unsubscribe a user', async () => {
+      const email = 'test@example.com';
+      const mockSubscription = { id: '1', email, isUnsubscribed: false } as NewsletterSubscription;
+
+      // Mock `findOne` to return a subscribed user
+      jest.spyOn(repository, 'findOne').mockResolvedValue(mockSubscription);
+      // Mock `save` to return updated object
+      jest.spyOn(repository, 'save').mockImplementation(
+        async sub =>
+          ({
+            ...sub,
+            isUnsubscribed: true,
+            email: sub.email,
+            deletedAt: sub.deletedAt || new Date(),
+            id: sub.id,
+            created_at: sub.created_at || new Date(),
+            updated_at: new Date(),
+          }) as NewsletterSubscription
+      );
+
+      const result = await service.unsubscribe(email);
+      expect(result).toEqual({ message: `Email ${email} has been unsubscribed successfully` });
+
+      // Ensure `isUnsubscribed` was updated
+      expect(repository.save).toHaveBeenCalledWith(expect.objectContaining({ isUnsubscribed: true }));
+    });
+
+    it('should throw NotFoundException if email is not found', async () => {
+      const email = 'notfound@example.com';
+
+      // Mock `findOne` to return null
+      jest.spyOn(repository, 'findOne').mockResolvedValue(null);
+
+      // Expecting an error
+      await expect(service.unsubscribe(email)).rejects.toThrow(
+        new NotFoundException(`Email ${email} not found in the subscription list`)
+      );
+
+      expect(repository.findOne).toHaveBeenCalledWith({ where: { email } });
+    });
+  });
 });


### PR DESCRIPTION
# Pull Request: Unsubscribe Feature for Newsletter

## Description

This PR adds the ability for users to unsubscribe from the newsletter. The following updates were made:

- Added an `unsubscribe` endpoint (`POST /newsletter-subscription/unsubscribe`).
- Modified the `NewsletterSubscription` entity to include an `isUnsubscribed` flag.
- Implemented `unsubscribe` logic in the `NewsletterSubscriptionService`.
- Updated the `NewsletterSubscriptionController` with an unsubscribe handler.
- Added unit tests for the unsubscribe functionality.

## Related Issue

<!-- Link to the related issue(s) this PR addresses -->

Fixes #1225 

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation updates
- [ ] style: Code style/formatting changes
- [ ] refactor: Code refactoring
- [ ] perf: Performance improvements
- [x] test: Test additions/updates
- [ ] chore: Build process or tooling changes
- [ ] ci: CI configuration changes
- [ ] other: <!-- describe -->

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

## Test Evidence

<!-- Please upload a screenshot showing all tests passing -->
![image](https://github.com/user-attachments/assets/d02e5b18-2131-4a87-a01d-e40e5eef4f9d)

<!-- This is required for all PRs that include code changes -->

✅ **Tested Unsubscribe Flow**
- User is marked as `isUnsubscribed: true` after unsubscribing.
- Returns `NotFoundException` if email is not found.
- Ensures `repository.save` is called with updated data.

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes if UI is affected -->

## Documentation Screenshots (if applicable)

<!-- If you've made code changes, please add screenshots of the updated documentation -->
<!-- This is required for all PRs that include code changes that affect user-facing features -->

## Checklist

<!-- Mark the appropriate option with an "x" -->

- [x] My code follows the project's coding style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have included a screenshot showing all tests passing
- [x] I have included documentation screenshots (if applicable)

## Additional Notes

- This update ensures that users can opt out of newsletters without being permanently removed from the system.
- Future improvement: Consider implementing a **resubscribe feature** to allow users to opt back in.

