### PR TITLE
feat(language): Implement DELETE endpoint for user-specific language deletion

### DIFF
--- a/src/modules/languages/languages.controller.ts
+++ b/src/modules/languages/languages.controller.ts
@@ -1,4 +1,19 @@
-import { Controller, Post, Body, Get, Patch, Param, Res, Request, Response, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  Get,
+  Patch,
+  Param,
+  Res,
+  Request,
+  Response,
+  UseGuards,
+  BadRequestException,
+  Delete,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBody, ApiBearerAuth } from '@nestjs/swagger';
 import { CreateLanguageDto, UpdateLanguageDto } from './dto/create-language.dto';
 import { LanguagesService } from './languages.service';
@@ -8,71 +23,88 @@ import { NotFoundException, UnauthorizedException } from '@nestjs/common';
 @ApiTags('Languages')
 @Controller('languages')
 export class LanguagesController {
-    constructor(private readonly languagesService: LanguagesService) { }
+  constructor(private readonly languagesService: LanguagesService) {}
 
-    @Post()
-    @ApiBearerAuth()
-    @ApiOperation({ summary: 'Create a new language' })
-    @ApiBody({ type: CreateLanguageDto })
-    @ApiResponse({ status: 201, description: 'Language successfully created.' })
-    @ApiResponse({ status: 409, description: 'Language already exists.' })
-    @ApiResponse({ status: 401, description: 'Unauthorized' })
-    async createLanguage(@Body() createLanguageDto: CreateLanguageDto) {
-        return this.languagesService.createLanguage(createLanguageDto);
+  @Post()
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a new language' })
+  @ApiBody({ type: CreateLanguageDto })
+  @ApiResponse({ status: 201, description: 'Language successfully created.' })
+  @ApiResponse({ status: 409, description: 'Language already exists.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async createLanguage(@Body() createLanguageDto: CreateLanguageDto) {
+    return this.languagesService.createLanguage(createLanguageDto);
+  }
+
+  @Get()
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all supported languages' })
+  @ApiResponse({ status: 200, description: 'List of supported languages.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async getLanguages(@Response() response): Promise<any> {
+    const result = await this.languagesService.getSupportedLanguages();
+    return response.status(result.status_code).json(result);
+  }
+
+  @Get(':id')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all languages from a userId' })
+  @ApiResponse({ status: 200, description: 'List of  languages by the user.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 400, description: 'Invalid UserId' })
+  @ApiResponse({ status: 404, description: 'No languages found for the specified user' })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  async getLanguagesByUserId(@Param('id') id: string, @Request() req, @Response() response): Promise<any> {
+    const result = await this.languagesService.getLanguagesById(id, req.user);
+    return response.status(result.status_code).json(result);
+  }
+
+  @Patch(':id')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a language' })
+  @ApiBody({ type: UpdateLanguageDto })
+  @ApiResponse({ status: 200, description: 'Language successfully updated.' })
+  @ApiResponse({ status: 404, description: 'Language not found.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async updateLanguage(@Param('id') id: string, @Body() updateLanguageDto: UpdateLanguageDto) {
+    return this.languagesService.updateLanguage(id, updateLanguageDto);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard)
+  @ApiOperation({ summary: 'Get all languages by User ID' })
+  @ApiResponse({ status: 200, description: 'Returns languages associated with user.' })
+  @ApiResponse({ status: 404, description: 'User not found or no languages available.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized access.' })
+  @Get(':id/languages')
+  async getUserLanguages(@Param('id') userId: string) {
+    if (!userId) {
+      throw new UnauthorizedException('Invalid user ID.');
     }
 
-    @Get()
-    @ApiBearerAuth()
-    @ApiOperation({ summary: 'Get all supported languages' })
-    @ApiResponse({ status: 200, description: 'List of supported languages.' })
-    @ApiResponse({ status: 401, description: 'Unauthorized' })
-    async getLanguages(@Response() response): Promise<any> {
-        const result = await this.languagesService.getSupportedLanguages();
-        return response.status(result.status_code).json(result);
+    const languages = await this.languagesService.getUserLanguages(userId);
+
+    if (!languages.length) {
+      throw new NotFoundException('No languages found for this user.');
     }
 
-    @Get(':id')
-    @ApiBearerAuth()
-    @ApiOperation({ summary: 'Get all languages from a userId' })
-    @ApiResponse({ status: 200, description: 'List of  languages by the user.' })
-    @ApiResponse({ status: 401, description: 'Unauthorized' })
-    @ApiResponse({ status: 400, description: 'Invalid UserId' })
-    @ApiResponse({ status: 404, description: 'No languages found for the specified user' })
-    @ApiResponse({ status: 500, description: 'Internal server error' })
-    async getLanguagesByUserId(@Param('id') id: string, @Request() req, @Response() response): Promise<any> {
-        const result = await this.languagesService.getLanguagesById(id, req.user);
-        return response.status(result.status_code).json(result);
+    return { status: 200, data: languages };
+  }
+
+  @Delete(':id')
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard)
+  @ApiOperation({ summary: 'Delete a specific user language by ID' })
+  @ApiResponse({ status: 200, description: 'Language successfully deleted for the user.' })
+  @ApiResponse({ status: 400, description: 'Cannot delete language due to dependencies.' })
+  @ApiResponse({ status: 404, description: 'Language not found for the user.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized access.' })
+  @ApiResponse({ status: 403, description: 'User not authorized to delete this language.' })
+  @HttpCode(HttpStatus.OK)
+  async deleteUserLanguage(@Param('id') languageId: string, @Request() req) {
+    if (!languageId) {
+      throw new BadRequestException('Invalid language ID provided.');
     }
-
-    @Patch(':id')
-    @ApiBearerAuth()
-    @ApiOperation({ summary: 'Update a language' })
-    @ApiBody({ type: UpdateLanguageDto })
-    @ApiResponse({ status: 200, description: 'Language successfully updated.' })
-    @ApiResponse({ status: 404, description: 'Language not found.' })
-    @ApiResponse({ status: 401, description: 'Unauthorized' })
-    async updateLanguage(@Param('id') id: string, @Body() updateLanguageDto: UpdateLanguageDto) {
-        return this.languagesService.updateLanguage(id, updateLanguageDto);
-    }
-
-    @ApiBearerAuth()
-    @UseGuards(AuthGuard)
-    @ApiOperation({ summary: 'Get all languages by User ID' })
-    @ApiResponse({ status: 200, description: 'Returns languages associated with user.' })
-    @ApiResponse({ status: 404, description: 'User not found or no languages available.' })
-    @ApiResponse({ status: 401, description: 'Unauthorized access.' })
-    @Get(':id/languages')
-    async getUserLanguages(@Param('id') userId: string) {
-        if (!userId) {
-            throw new UnauthorizedException('Invalid user ID.');
-        }
-
-        const languages = await this.languagesService.getUserLanguages(userId);
-
-        if (!languages.length) {
-            throw new NotFoundException('No languages found for this user.');
-        }
-
-        return { status: 200, data: languages };
-    }
+    return await this.languagesService.deleteUserLanguage(languageId, req.user.id);
+  }
 }

--- a/src/modules/languages/languages.service.ts
+++ b/src/modules/languages/languages.service.ts
@@ -1,12 +1,12 @@
 import {
-    BadRequestException,
-    ConflictException,
-    ForbiddenException,
-    HttpStatus,
-    Injectable,
-    InternalServerErrorException,
-    Logger,
-    NotFoundException,
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  HttpStatus,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -17,153 +17,172 @@ import { isUUID } from 'class-validator';
 
 @Injectable()
 export class LanguagesService {
-    constructor(
-        @InjectRepository(Language)
-        private readonly languageRepository: Repository<Language>,
-        @InjectRepository(User)
-        private readonly userRepository: Repository<User>,
-    ) { }
+  constructor(
+    @InjectRepository(Language)
+    private readonly languageRepository: Repository<Language>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>
+  ) {}
 
-    async createLanguage(createLanguageDto: CreateLanguageDto): Promise<any> {
-        try {
-            const languageExists = await this.languageRepository.findOne({
-                where: { language: createLanguageDto.language },
-            });
+  async createLanguage(createLanguageDto: CreateLanguageDto): Promise<any> {
+    try {
+      const languageExists = await this.languageRepository.findOne({
+        where: { language: createLanguageDto.language },
+      });
 
-            if (languageExists) {
-                throw new ConflictException({
-                    status_code: HttpStatus.CONFLICT,
-                    message: 'Language already exists',
-                });
-            }
+      if (languageExists) {
+        throw new ConflictException({
+          status_code: HttpStatus.CONFLICT,
+          message: 'Language already exists',
+        });
+      }
 
-            const newLanguage = this.languageRepository.create(createLanguageDto);
-            await this.languageRepository.save(newLanguage);
+      const newLanguage = this.languageRepository.create(createLanguageDto);
+      await this.languageRepository.save(newLanguage);
 
-            return {
-                status_code: HttpStatus.CREATED,
-                message: 'Language Created Successfully',
-                language: newLanguage,
-            };
-        } catch (error) {
-            if (error instanceof ConflictException) {
-                throw error;
-            }
-            Logger.error('LanguagesServiceError ~ createLanguage ~', error);
-            throw new InternalServerErrorException({
-                message: 'An error occurred',
-                status_code: HttpStatus.INTERNAL_SERVER_ERROR,
-            });
-        }
+      return {
+        status_code: HttpStatus.CREATED,
+        message: 'Language Created Successfully',
+        language: newLanguage,
+      };
+    } catch (error) {
+      if (error instanceof ConflictException) {
+        throw error;
+      }
+      Logger.error('LanguagesServiceError ~ createLanguage ~', error);
+      throw new InternalServerErrorException({
+        message: 'An error occurred',
+        status_code: HttpStatus.INTERNAL_SERVER_ERROR,
+      });
+    }
+  }
+
+  async getSupportedLanguages(): Promise<any> {
+    try {
+      const languages = await this.languageRepository.find();
+      const formattedLanguages = languages.map(language => ({
+        language: `${language.language} (${language.description})`,
+      }));
+      return {
+        status_code: HttpStatus.OK,
+        message: 'Languages fetched successfully',
+        languages: formattedLanguages,
+      };
+    } catch (error) {
+      Logger.error('LanguagesServiceError ~ fetchLanguages ~', error);
+      throw new InternalServerErrorException({
+        message: 'An error occurred',
+        status_code: HttpStatus.INTERNAL_SERVER_ERROR,
+      });
+    }
+  }
+
+  async updateLanguage(id: string, updateLanguageDto: UpdateLanguageDto): Promise<any> {
+    try {
+      const language = await this.languageRepository.findOne({ where: { id } });
+      if (!language) {
+        throw new NotFoundException({
+          status_code: HttpStatus.NOT_FOUND,
+          message: 'Language not found',
+        });
+      }
+
+      Object.assign(language, updateLanguageDto);
+      await this.languageRepository.save(language);
+
+      return {
+        status_code: HttpStatus.OK,
+        message: 'Language successfully updated',
+        language,
+      };
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      Logger.error('LanguagesServiceError ~ updateLanguage ~', error);
+      throw new InternalServerErrorException({
+        message: 'An error occurred',
+        status_code: HttpStatus.INTERNAL_SERVER_ERROR,
+      });
+    }
+  }
+  async getLanguagesById(userId: string, user: User): Promise<any> {
+    try {
+      if (!isUUID(userId)) {
+        throw new BadRequestException('Invalid user Id');
+      }
+
+      if (user.id !== userId) {
+        throw new ForbiddenException({
+          status_code: HttpStatus.FORBIDDEN,
+          message: 'You are not authorized to access this resource',
+        });
+      }
+
+      const languages = await this.languageRepository
+        .createQueryBuilder('language')
+        .innerJoin('language.users', 'user')
+        .where('user.id = :userId', { userId })
+        .getMany();
+
+      if (!languages || languages.length === 0) {
+        throw new NotFoundException({
+          status_code: HttpStatus.NOT_FOUND,
+          message: 'Languages associated with this user not found',
+        });
+      }
+
+      const formattedLanguages = languages.map(language => ({
+        id: language.id,
+        language: language.language,
+        description: language.description,
+        code: language.code,
+      }));
+
+      return {
+        status: 'OK',
+        status_code: HttpStatus.OK,
+        message: 'Languages fetched successfully',
+        data: formattedLanguages,
+      };
+    } catch (error) {
+      if (
+        error instanceof NotFoundException ||
+        error instanceof ForbiddenException ||
+        error instanceof BadRequestException
+      ) {
+        throw error;
+      }
+      Logger.error('LanguagesServiceError ~ getLanguagesById ~', error);
+      throw new InternalServerErrorException({
+        message: 'An error occurred',
+        status_code: HttpStatus.INTERNAL_SERVER_ERROR,
+      });
+    }
+  }
+
+  async getUserLanguages(userId: string): Promise<Language[]> {
+    const user = await this.userRepository.findOne({ where: { id: userId }, relations: ['languages'] });
+    if (!user) throw new NotFoundException('User not found.');
+    return user.languages || [];
+  }
+
+  async deleteUserLanguage(languageId: string, userId: string): Promise<{ message: string }> {
+    const user = await this.userRepository.findOne({ where: { id: userId }, relations: ['languages'] });
+    if (!user) {
+      throw new NotFoundException('User not found.');
     }
 
-    async getSupportedLanguages(): Promise<any> {
-        try {
-            const languages = await this.languageRepository.find();
-            const formattedLanguages = languages.map(language => ({
-                language: `${language.language} (${language.description})`,
-            }));
-            return {
-                status_code: HttpStatus.OK,
-                message: 'Languages fetched successfully',
-                languages: formattedLanguages,
-            };
-        } catch (error) {
-            Logger.error('LanguagesServiceError ~ fetchLanguages ~', error);
-            throw new InternalServerErrorException({
-                message: 'An error occurred',
-                status_code: HttpStatus.INTERNAL_SERVER_ERROR,
-            });
-        }
+    const language = user.languages.find(lang => lang.id === languageId);
+    if (!language) {
+      throw new NotFoundException('Language not found for this user.');
     }
 
-    async updateLanguage(id: string, updateLanguageDto: UpdateLanguageDto): Promise<any> {
-        try {
-            const language = await this.languageRepository.findOne({ where: { id } });
-            if (!language) {
-                throw new NotFoundException({
-                    status_code: HttpStatus.NOT_FOUND,
-                    message: 'Language not found',
-                });
-            }
-
-            Object.assign(language, updateLanguageDto);
-            await this.languageRepository.save(language);
-
-            return {
-                status_code: HttpStatus.OK,
-                message: 'Language successfully updated',
-                language,
-            };
-        } catch (error) {
-            if (error instanceof NotFoundException) {
-                throw error;
-            }
-            Logger.error('LanguagesServiceError ~ updateLanguage ~', error);
-            throw new InternalServerErrorException({
-                message: 'An error occurred',
-                status_code: HttpStatus.INTERNAL_SERVER_ERROR,
-            });
-        }
+    try {
+      await this.languageRepository.remove(language);
+      return { message: 'Language successfully deleted for the user.' };
+    } catch (error) {
+      throw new BadRequestException('Cannot delete language due to dependencies.');
     }
-    async getLanguagesById(userId: string, user: User): Promise<any> {
-        try {
-            if (!isUUID(userId)) {
-                throw new BadRequestException('Invalid user Id');
-            }
-
-            if (user.id !== userId) {
-                throw new ForbiddenException({
-                    status_code: HttpStatus.FORBIDDEN,
-                    message: 'You are not authorized to access this resource',
-                });
-            }
-
-            const languages = await this.languageRepository
-                .createQueryBuilder('language')
-                .innerJoin('language.users', 'user')
-                .where('user.id = :userId', { userId })
-                .getMany();
-
-            if (!languages || languages.length === 0) {
-                throw new NotFoundException({
-                    status_code: HttpStatus.NOT_FOUND,
-                    message: 'Languages associated with this user not found',
-                });
-            }
-
-            const formattedLanguages = languages.map(language => ({
-                id: language.id,
-                language: language.language,
-                description: language.description,
-                code: language.code,
-            }));
-
-            return {
-                status: 'OK',
-                status_code: HttpStatus.OK,
-                message: 'Languages fetched successfully',
-                data: formattedLanguages,
-            };
-        } catch (error) {
-            if (
-                error instanceof NotFoundException ||
-                error instanceof ForbiddenException ||
-                error instanceof BadRequestException
-            ) {
-                throw error;
-            }
-            Logger.error('LanguagesServiceError ~ getLanguagesById ~', error);
-            throw new InternalServerErrorException({
-                message: 'An error occurred',
-                status_code: HttpStatus.INTERNAL_SERVER_ERROR,
-            });
-        }
-    }
-
-    async getUserLanguages(userId: string): Promise<Language[]> {
-        const user = await this.userRepository.findOne({ where: { id: userId }, relations: ['languages'] });
-        if (!user) throw new NotFoundException('User not found.');
-        return user.languages || [];
-    }
+  }
 }

--- a/src/modules/languages/tests/languages.service.spec.ts
+++ b/src/modules/languages/tests/languages.service.spec.ts
@@ -20,6 +20,7 @@ const mockLanguageRepository = {
   create: jest.fn(),
   save: jest.fn(),
   find: jest.fn(),
+  remove: jest.fn(),
   createQueryBuilder: jest.fn(() => ({
     innerJoin: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
@@ -53,6 +54,7 @@ describe('LanguagesService', () => {
 
     service = module.get<LanguagesService>(LanguagesService);
     repository = module.get<Repository<Language>>(getRepositoryToken(Language));
+    userRepository = module.get<Repository<User>>(getRepositoryToken(User));
   });
 
   it('should be defined', () => {
@@ -161,6 +163,37 @@ describe('LanguagesService', () => {
     it('should throw NotFoundException if user does not exist', async () => {
       jest.spyOn(userRepository, 'findOne').mockResolvedValue(null);
       await expect(languageService.getUserLanguages('123')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('deleteUserLanguage', () => {
+    it('should delete a user-specific language successfully', async () => {
+      const mockUser = { id: 'user123', languages: [{ id: 'lang123', language: 'English' }] } as User;
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(mockUser);
+      jest.spyOn(repository, 'remove').mockResolvedValue(null);
+
+      await expect(service.deleteUserLanguage('lang123', 'user123')).resolves.toEqual({
+        message: 'Language successfully deleted for the user.',
+      });
+    });
+
+    it('should throw NotFoundException if user does not exist', async () => {
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(null);
+      await expect(service.deleteUserLanguage('lang123', 'user123')).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw NotFoundException if language is not found for user', async () => {
+      const mockUser = { id: 'user123', languages: [] } as User;
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(mockUser);
+      await expect(service.deleteUserLanguage('lang123', 'user123')).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw BadRequestException if language has dependencies', async () => {
+      const mockUser = { id: 'user123', languages: [{ id: 'lang123', language: 'English' }] } as User;
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(mockUser);
+      jest.spyOn(repository, 'remove').mockRejectedValue(new Error('Cannot delete'));
+
+      await expect(service.deleteUserLanguage('lang123', 'user123')).rejects.toThrow(BadRequestException);
     });
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

This PR introduces a new **DELETE API endpoint** that allows users to delete a specific language associated with their account. It includes:  

 **New Controller Method:** `DELETE /languages/:id`  
 **Service Method:** `deleteUserLanguage(languageId, userId)`  
 **Validation:**  
- Ensures the language exists for the requesting user.  
- Prevents deletion if dependencies exist.  
 **Error Handling:**  
- Returns `404 Not Found` if the language does not belong to the user.  
- Returns `400 Bad Request` if dependencies prevent deletion.  
 **Unit Tests:**  
- Added test cases for successful and failed deletions.  

## Related Issue

<!-- Link to the related issue(s) this PR addresses -->

Fixes #1074 

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation updates
- [ ] style: Code style/formatting changes
- [ ] refactor: Code refactoring
- [ ] perf: Performance improvements
- [ ] test: Test additions/updates
- [ ] chore: Build process or tooling changes
- [ ] ci: CI configuration changes
- [ ] other: <!-- describe -->

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

## Test Evidence

<!-- Please upload a screenshot showing all tests passing -->
<!-- This is required for all PRs that include code changes -->
![Screenshot](https://files.catbox.moe/hsbuqt.png)
## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes if UI is affected -->

## Documentation Screenshots (if applicable)

<!-- If you've made code changes, please add screenshots of the updated documentation -->
<!-- This is required for all PRs that include code changes that affect user-facing features -->

## Checklist

<!-- Mark the appropriate option with an "x" -->

- [x] My code follows the project's coding style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have included a screenshot showing all tests passing
- [ ] I have included documentation screenshots (if applicable)

## Additional Notes

<!-- Add any other information about the PR here -->
