### PR TITLE
fix: validate and prevent duplicate job applications

### DIFF
--- a/src/modules/jobs/jobs.service.ts
+++ b/src/modules/jobs/jobs.service.ts
@@ -40,19 +40,26 @@ export class JobsService {
 
     const { resume, applicant_name, ...others } = jobApplicationDto;
 
-    // TODO: Upload resume to the cloud and grab URL
+    const existingApplication = await this.jobApplicationRepository.findOne({
+      where: { job: { id: jobId }, applicant_name: jobApplicationDto.applicant_name },
+      relations: ['job'],
+    });
 
+    if (existingApplication) {
+      throw new CustomHttpException('Duplicate application', HttpStatus.BAD_REQUEST);
+    }
+
+    // TODO: Upload resume to the cloud and grab URL
     const resumeUrl = `https://example.com/${applicant_name.split(' ').join('_')}.pdf`;
 
     const createJobApplication = this.jobApplicationRepository.create({
       ...others,
       applicant_name,
       resume: resumeUrl,
-      ...job,
+      job: job.data,
     });
 
     await this.jobApplicationRepository.save(createJobApplication);
-
     return {
       status: 'success',
       message: 'Application submitted successfully',

--- a/src/modules/jobs/tests/jobs.service.spec.ts
+++ b/src/modules/jobs/tests/jobs.service.spec.ts
@@ -190,9 +190,18 @@ describe('JobsService', () => {
         ...mockJobApplicationDto,
         applicant_name: 'John Doe',
         resume: `https://example.com/John_Doe.pdf`,
-        ...mockJob,
+        job: mockJob.data,
       });
       expect(saveMock).toHaveBeenCalled();
+    });
+
+    it('should throw error if duplicate application is found', async () => {
+      jest.spyOn(service, 'getJob').mockResolvedValue(mockJob as any);
+      jest.spyOn(service['jobApplicationRepository'], 'findOne').mockResolvedValue(mockJobApplicationDto as any);
+
+      await expect(service.applyForJob('jobId', mockJobApplicationDto)).rejects.toThrow(
+        new CustomHttpException('Duplicate application', HttpStatus.CONFLICT)
+      );
     });
   });
 


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes an issue where duplicate job applications could be submitted. It introduces a validation check to prevent multiple applications for the same job by the same user.

## Related Issue

Fixes #1277 

## Type of Change

- [x] fix: Bug fix
- [x] test: Test additions/updates
- [ ] chore: Build process or tooling changes

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] Manual tests

## Test Evidence

![test001](https://github.com/user-attachments/assets/dcfd438e-7dfa-4b3e-a048-26b0668f6a8a)
![application-200](https://github.com/user-attachments/assets/43f1e1b4-1a09-4d85-b19d-1a8e03a6a954)
![application-400](https://github.com/user-attachments/assets/2579dad6-6360-4587-bcbc-0812d91d7429)



## Screenshots (if applicable)

## Documentation Screenshots (if applicable)

## Checklist

<!-- Mark the appropriate option with an "x" -->

- [x] My code follows the project's coding style
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have included a screenshot showing all tests passing

## Additional Notes

